### PR TITLE
Implement Encoder builder manually

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ unstable = []
 [dependencies]
 bitflags = "1"
 byteorder = "1"
-derive_builder = "0.7"
 encoding = "0.2"
 flate2 = "1"
 lazy_static = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,12 +44,9 @@
 
 #![warn(missing_docs)]
 
-#[macro_use]
-extern crate derive_builder;
-
 pub use crate::error::{Error, ErrorKind, Result};
 pub use crate::frame::{Content, Frame, Timestamp};
-pub use crate::stream::tag::{Encoder, EncoderBuilder};
+pub use crate::stream::tag::Encoder;
 pub use crate::tag::{Tag, Version};
 
 /// Contains types and methods for operating on ID3 frames.

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -1208,10 +1208,8 @@ impl<'a> Tag {
 
     /// Attempts to write the ID3 tag to the writer using the specified version.
     pub fn write_to(&self, writer: impl io::Write, version: Version) -> crate::Result<()> {
-        stream::tag::EncoderBuilder::default()
+        stream::tag::Encoder::new()
             .version(version)
-            .build()
-            .unwrap()
             .encode(self, writer)
     }
 


### PR DESCRIPTION
Being used once and not using any of the advanced features, I don't think `derive_builder` pulls its weight here. This drops the release build time from 66 s to 18 s on my system, and makes things cleaner for other users (e.g. the current `derive_builder` depends on a pre-1.0 `syn`).

This is a breaking change, but we could preserve API compatibility if we wanted (the new API is nicer IMHO).