### PR TITLE
Implement a timestamp parser

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ byteorder = "1"
 encoding = "0.2"
 flate2 = "1"
 lazy_static = "1"
-regex = "1"
 
 [dev-dependencies]
 tempdir = "0.3"


### PR DESCRIPTION
This removes the `regex` dependency and further reduces release build times from 18s to 7s (on top of #34).

It's not necessarily ready because there's a behavior change: the old parser accepted any number of digits for years, and one or two for the other date parts. I should implement the same thing, because it's likely that some non-conforming files exist in the wild.