### PR TITLE
feat: add read_from_path function for v1 tag

### DIFF
--- a/src/v1/mod.rs
+++ b/src/v1/mod.rs
@@ -3,6 +3,7 @@ use std::cmp;
 use std::fs;
 use std::io::{self, Read, Seek};
 use std::ops;
+use std::path::Path;
 
 /// Location of the ID3v1 tag chunk relative to the end of the file.
 static TAG_CHUNK: ops::Range<i64> = -128..0;
@@ -292,6 +293,12 @@ impl Tag {
             start_time,
             end_time,
         })
+    }
+
+    /// Attempts to read an ID3v1 tag from the file at the indicated path.
+    pub fn read_from_path(path: impl AsRef<Path>) -> crate::Result<Tag> {
+        let file = fs::File::open(path)?;
+        Tag::read_from(file)
     }
 
     /// Removes an ID3v1 tag plus possible extended data if any.


### PR DESCRIPTION
Hello

At first I was working with `v2` tags on files, using `read_from_path`. But then when I started to dig into `v1` tags, I found that the convenient `read_from_path` was missing for this version.

Therefore this PR adds it for consistency between `v1` and `v2` handling.