### PR TITLE
Improve text rendering of Frame and Content

### DIFF
--- a/src/frame/content.rs
+++ b/src/frame/content.rs
@@ -270,7 +270,7 @@ impl SynchronisedLyrics {
     /// # Errors
     ///
     /// This function will return any I/O error reported while formatting.
-    pub fn fmt_table(&self, writer: &mut impl io::Write) -> io::Result<()> {
+    pub fn fmt_table(&self, mut writer: impl io::Write) -> io::Result<()> {
         match self.timestamp_format {
             TimestampFormat::MPEG => {
                 write!(writer, "Frame\t{}\n", self.content_type)?;

--- a/src/frame/mod.rs
+++ b/src/frame/mod.rs
@@ -306,7 +306,7 @@ impl Frame {
             "WPB" => "Publishers official webpage",
             "WXX" => "User defined URL link frame",
 
-            _ => self.id(),
+            v => v,
         }
     }
 }

--- a/src/frame/mod.rs
+++ b/src/frame/mod.rs
@@ -130,28 +130,190 @@ impl Frame {
     pub fn set_file_alter_preservation(&mut self, file_alter_preservation: bool) {
         self.file_alter_preservation = file_alter_preservation;
     }
+
+    /// Returns the name of the frame.
+    ///
+    /// The name is the _human-readable_ representation of a frame
+    /// id. For example, the id `"TCOM"` corresponds to the name
+    /// `"Composer"`. The names are taken from the
+    /// [ID3v2.4](http://id3.org/id3v2.4.0-frames),
+    /// [ID3v2.3](http://id3.org/d3v2.3.0) and
+    /// [ID3v2.2](http://id3.org/d3v2-00) standards.
+    pub fn name(&self) -> &str {
+        match self.id() {
+            // Ids and names defined in section 4 of http://id3.org/id3v2.4.0-frames
+            "AENC" => "Audio encryption",
+            "APIC" => "Attached picture",
+            "ASPI" => "Audio seek point index",
+            "COMM" => "Comments",
+            "COMR" => "Commercial frame",
+            "ENCR" => "Encryption method registration",
+            "EQU2" => "Equalisation (2)",
+            "ETCO" => "Event timing codes",
+            "GEOB" => "General encapsulated object",
+            "GRID" => "Group identification registration",
+            "LINK" => "Linked information",
+            "MCDI" => "Music CD identifier",
+            "MLLT" => "MPEG location lookup table",
+            "OWNE" => "Ownership frame",
+            "PRIV" => "Private frame",
+            "PCNT" => "Play counter",
+            "POPM" => "Popularimeter",
+            "POSS" => "Position synchronisation frame",
+            "RBUF" => "Recommended buffer size",
+            "RVA2" => "Relative volume adjustment (2)",
+            "RVRB" => "Reverb",
+            "SEEK" => "Seek frame",
+            "SIGN" => "Signature frame",
+            "SYLT" => "Synchronised lyric/text",
+            "SYTC" => "Synchronised tempo codes",
+            "TALB" => "Album/Movie/Show title",
+            "TBPM" => "BPM (beats per minute)",
+            "TCOM" => "Composer",
+            "TCON" => "Content type",
+            "TCOP" => "Copyright message",
+            "TDEN" => "Encoding time",
+            "TDLY" => "Playlist delay",
+            "TDOR" => "Original release time",
+            "TDRC" => "Recording time",
+            "TDRL" => "Release time",
+            "TDTG" => "Tagging time",
+            "TENC" => "Encoded by",
+            "TEXT" => "Lyricist/Text writer",
+            "TFLT" => "File type",
+            "TIPL" => "Involved people list",
+            "TIT1" => "Content group description",
+            "TIT2" => "Title/songname/content description",
+            "TIT3" => "Subtitle/Description refinement",
+            "TKEY" => "Initial key",
+            "TLAN" => "Language(s)",
+            "TLEN" => "Length",
+            "TMCL" => "Musician credits list",
+            "TMED" => "Media type",
+            "TMOO" => "Mood",
+            "TOAL" => "Original album/movie/show title",
+            "TOFN" => "Original filename",
+            "TOLY" => "Original lyricist(s)/text writer(s)",
+            "TOPE" => "Original artist(s)/performer(s)",
+            "TOWN" => "File owner/licensee",
+            "TPE1" => "Lead performer(s)/Soloist(s)",
+            "TPE2" => "Band/orchestra/accompaniment",
+            "TPE3" => "Conductor/performer refinement",
+            "TPE4" => "Interpreted, remixed, or otherwise modified by",
+            "TPOS" => "Part of a set",
+            "TPRO" => "Produced notice",
+            "TPUB" => "Publisher",
+            "TRCK" => "Track number/Position in set",
+            "TRSN" => "Internet radio station name",
+            "TRSO" => "Internet radio station owner",
+            "TSOA" => "Album sort order",
+            "TSOP" => "Performer sort order",
+            "TSOT" => "Title sort order",
+            "TSRC" => "ISRC (international standard recording code)",
+            "TSSE" => "Software/Hardware and settings used for encoding",
+            "TSST" => "Set subtitle",
+            "TXXX" => "User defined text information frame",
+            "UFID" => "Unique file identifier",
+            "USER" => "Terms of use",
+            "USLT" => "Unsynchronised lyric/text transcription",
+            "WCOM" => "Commercial information",
+            "WCOP" => "Copyright/Legal information",
+            "WOAF" => "Official audio file webpage",
+            "WOAR" => "Official artist/performer webpage",
+            "WOAS" => "Official audio source webpage",
+            "WORS" => "Official Internet radio station homepage",
+            "WPAY" => "Payment",
+            "WPUB" => "Publishers official webpage",
+            "WXXX" => "User defined URL link frame",
+
+            // Ids and names defined in section 4 of
+            // http://id3.org/d3v2.3.0 which have not been previously
+            // defined above
+            "EQUA" => "Equalization",
+            "IPLS" => "Involved people list",
+            "RVAD" => "Relative volume adjustment",
+            "TDAT" => "Date",
+            "TIME" => "Time",
+            "TORY" => "Original release year",
+            "TRDA" => "Recording dates",
+            "TSIZ" => "Size",
+            "TYER" => "Year",
+
+            // Ids and names defined in section 4 of
+            // http://id3.org/d3v2-00 which have not been previously
+            // defined above
+            "BUF" => "Recommended buffer size",
+            "CNT" => "Play counter",
+            "COM" => "Comments",
+            "CRA" => "Audio encryption",
+            "CRM" => "Encrypted meta frame",
+            "ETC" => "Event timing codes",
+            "EQU" => "Equalization",
+            "GEO" => "General encapsulated object",
+            "IPL" => "Involved people list",
+            "LNK" => "Linked information",
+            "MCI" => "Music CD Identifier",
+            "MLL" => "MPEG location lookup table",
+            "PIC" => "Attached picture",
+            "POP" => "Popularimeter",
+            "REV" => "Reverb",
+            "RVA" => "Relative volume adjustment",
+            "SLT" => "Synchronized lyric/text",
+            "STC" => "Synced tempo codes",
+            "TAL" => "Album/Movie/Show title",
+            "TBP" => "BPM (Beats Per Minute)",
+            "TCM" => "Composer",
+            "TCO" => "Content type",
+            "TCR" => "Copyright message",
+            "TDA" => "Date",
+            "TDY" => "Playlist delay",
+            "TEN" => "Encoded by",
+            "TFT" => "File type",
+            "TIM" => "Time",
+            "TKE" => "Initial key",
+            "TLA" => "Language(s)",
+            "TLE" => "Length",
+            "TMT" => "Media type",
+            "TOA" => "Original artist(s)/performer(s)",
+            "TOF" => "Original filename",
+            "TOL" => "Original Lyricist(s)/text writer(s)",
+            "TOR" => "Original release year",
+            "TOT" => "Original album/Movie/Show title",
+            "TP1" => "Lead artist(s)/Lead performer(s)/Soloist(s)/Performing group",
+            "TP2" => "Band/Orchestra/Accompaniment",
+            "TP3" => "Conductor/Performer refinement",
+            "TP4" => "Interpreted, remixed, or otherwise modified by",
+            "TPA" => "Part of a set",
+            "TPB" => "Publisher",
+            "TRC" => "ISRC (International Standard Recording Code)",
+            "TRD" => "Recording dates",
+            "TRK" => "Track number/Position in set",
+            "TSI" => "Size",
+            "TSS" => "Software/hardware and settings used for encoding",
+            "TT1" => "Content group description",
+            "TT2" => "Title/Songname/Content description",
+            "TT3" => "Subtitle/Description refinement",
+            "TXT" => "Lyricist/text writer",
+            "TXX" => "User defined text information frame",
+            "TYE" => "Year",
+            "UFI" => "Unique file identifier",
+            "ULT" => "Unsychronized lyric/text transcription",
+            "WAF" => "Official audio file webpage",
+            "WAR" => "Official artist/performer webpage",
+            "WAS" => "Official audio source webpage",
+            "WCM" => "Commercial information",
+            "WCP" => "Copyright/Legal information",
+            "WPB" => "Publishers official webpage",
+            "WXX" => "User defined URL link frame",
+
+            _ => self.id(),
+        }
+    }
 }
 
 impl fmt::Display for Frame {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        match self.content {
-            Content::Text(ref content) | Content::Link(ref content) => write!(f, "{}", content),
-            Content::Lyrics(ref content) => write!(f, "{}", content.text),
-            Content::SynchronisedLyrics(ref content) => write!(f, "{:?}", content.content_type),
-            Content::ExtendedText(ref content) => {
-                write!(f, "{}: {}", content.description, content.value)
-            }
-            Content::ExtendedLink(ref content) => {
-                write!(f, "{}: {}", content.description, content.link)
-            }
-            Content::Comment(ref content) => write!(f, "{}: {}", content.description, content.text),
-            Content::Picture(ref content) => write!(
-                f,
-                "{}: {:?} ({:?})",
-                content.description, content.picture_type, content.mime_type
-            ),
-            Content::Unknown(ref content) => write!(f, "unknown, {} bytes", content.len()),
-        }
+        write!(f, "{} = {}", self.name(), self.content)
     }
 }
 
@@ -162,7 +324,10 @@ mod tests {
     #[test]
     fn test_display() {
         let title_frame = Frame::with_content("TIT2", Content::Text("title".to_owned()));
-        assert_eq!(format!("{}", title_frame), "title");
+        assert_eq!(
+            format!("{}", title_frame),
+            "Title/songname/content description = title"
+        );
 
         let txxx_frame = Frame::with_content(
             "TXXX",
@@ -171,6 +336,9 @@ mod tests {
                 value: "value".to_owned(),
             }),
         );
-        assert_eq!(format!("{}", txxx_frame), "description: value");
+        assert_eq!(
+            format!("{}", txxx_frame),
+            "User defined text information frame = description: value"
+        );
     }
 }


### PR DESCRIPTION
Add `name()` method to `Frame` which provides _human readable_
versions of the `Frame` Ids, e.g. `"TCOM" => "Composer"`.

Modify the `fmt::Display` implementation on `Frame` to return a string
of the form `"NAME = CONTENT"`.

Implement `fmt::Display` on `Content` and the struct and enums it
encapsulates.

Add `format_table()` method on `SynchronisedLyrics` which outputs a
plain text table.