### PR TITLE
Extend fmt::Display implementation for Error and add it for ErrorKind

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -121,6 +121,25 @@ impl fmt::Debug for Error {
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:?}", self)
+        match self.description.is_empty() {
+            true => write!(f, "{}", self.kind),
+            false => write!(f, "{}: {}", self.kind, self.description),
+        }
+    }
+}
+
+impl fmt::Display for ErrorKind {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            ErrorKind::Io(io_error) => write!(f, "IO: {}", io_error),
+            ErrorKind::StringDecoding(_) => write!(f, "StringDecoding"),
+            ErrorKind::NoTag => write!(f, "NoTag"),
+            ErrorKind::UnsupportedVersion(major, minor) => {
+                write!(f, "UnsupportedVersion: {}.{}", major, minor)
+            }
+            ErrorKind::Parsing => write!(f, "Parsing"),
+            ErrorKind::InvalidInput => write!(f, "InvalidInput"),
+            ErrorKind::UnsupportedFeature => write!(f, "UnsupportedFeature"),
+        }
     }
 }


### PR DESCRIPTION
Just finished the `fmt::Display` implementation for `Error` and `ErrorKind` - so I went with your first suggestion.

I was looking over the code to see how context and messages are provided to `Error`s, to work an appropriate way to display them to users. My implementation follows these rules, when a `Error` is formatted using `fmt::Display`:

- format the `ErrorKind` using `fmt::Display`
- if the `description` field is a non-empty String, append it like this: `": example_description"`

When an `ErrorKind` is formatted, usually just the name of the kind is displayed, exceptions are:

- `ErrorKind::Io` where the IO error is formatted as well
- `ErrorKind::UnsupportedVersion` where the version is formatted as well

I chose to not format the invalid bytes for the `StringDecoding` variant, as `fmt::Display` is not implemented on `Vec<u8>`, and I think it's not information, a standard user wishes to see.


I hope this approach is satisfying to you, if not let me know. And by the way: thanks for this library 🙏


--- edit:

I don't quite understand the failing style integration. If it's my fault, could you explain how to fix it?