### PR TITLE
Remove 'encoding' crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ unstable = []
 [dependencies]
 bitflags = "1"
 byteorder = "1"
-encoding = "0.2"
 flate2 = "1"
 lazy_static = "1"
 


### PR DESCRIPTION
Removes the `encoding` crate, which hasn't been updated in 4 years.

Also makes encoding about twice as fast and decoding about 1/3 faster (I haven't done a complete benchmark, I just did a quick test to make sure I didn't make it worst).

<!--
extern crate test;

#[bench]
fn str_to_utf16le(b: &mut test::Bencher) {
    let s = include_str!("../../customfile/public/sw.js");

    b.iter(|| {
        let encoded = string_to_utf16le(s);
        let _ = string_from_utf16le(&encoded);
    });
}

#[bench]
fn str_to_utf16be(b: &mut test::Bencher) {
    let s = include_str!("../../customfile/public/sw.js");

    b.iter(|| {
        let encoded = string_to_utf16be(s);
        let _ = string_from_utf16be(&encoded);
    });
}
-->