### PR TITLE
Decode non-standard iTunes GRP1 frames as `Text`

### DIFF
--- a/src/stream/frame/content.rs
+++ b/src/stream/frame/content.rs
@@ -62,6 +62,7 @@ pub fn decode(id: &str, mut reader: impl io::Read) -> crate::Result<Content> {
         "GEOB" | "GEO" => parse_geob(data.as_slice()),
         id if id.starts_with('T') => parse_text(data.as_slice()),
         id if id.starts_with('W') => parse_weblink(data.as_slice()),
+        "GRP1" => parse_text(data.as_slice()),
         _ => Ok(Content::Unknown(data)),
     }
 }


### PR DESCRIPTION
I haven't been able to find much information about what GRP1 frames can contain, but as far as I can tell they're just normal `Text` frames. If I'm understanding correctly, eyed3d decodes GRP1 frames the same way.

Tested this by setting a grouping in iTunes, and that worked just fine.