### PR TITLE
ID3v2.4 tag value splitting

### DIFF
--- a/src/frame/content.rs
+++ b/src/frame/content.rs
@@ -36,6 +36,14 @@ impl Content {
         }
     }
 
+    /// Returns split values of the `Text` frame or None if the value is not `Text`.
+    pub fn text_values(&self) -> Option<Vec<&str>> {
+        match *self {
+            Content::Text(ref content) => Some(content.split('\0').collect()),
+            _ => None,
+        }
+    }
+
     /// Returns the `ExtendedText` or None if the value is not `ExtendedText`.
     pub fn extended_text(&self) -> Option<&ExtendedText> {
         match *self {

--- a/src/frame/content.rs
+++ b/src/frame/content.rs
@@ -36,12 +36,11 @@ impl Content {
         }
     }
 
-    /// Returns split values of the `Text` frame or None if the value is not `Text`.
-    pub fn text_values(&self) -> Option<Vec<&str>> {
-        match *self {
-            Content::Text(ref content) => Some(content.split('\0').collect()),
-            _ => None,
-        }
+    /// Returns split values of the `Text` frame or None if the value is not `Text`. This is only
+    /// useful for ID3v2.4 tags, which support text frames containing multiple values separated by
+    /// null bytes. This method returns an iterator over the separated values.
+    pub fn text_values(&self) -> Option<impl Iterator<Item = &str>> {
+        self.text().map(|content| content.split('\0'))
     }
 
     /// Returns the `ExtendedText` or None if the value is not `ExtendedText`.

--- a/src/stream/frame/content.rs
+++ b/src/stream/frame/content.rs
@@ -1006,7 +1006,40 @@ mod tests {
             let mut data = Vec::new();
             data.push(*encoding as u8);
             data.extend(bytes_for_encoding(text, *encoding).into_iter());
-            println!("bytes: {:?}", data);
+
+            assert_eq!(
+                decode("TALB", tag::Id3v24, &data[..])
+                    .unwrap()
+                    .text()
+                    .unwrap(),
+                "text\u{0}text"
+            );
+            let mut data_out = Vec::new();
+            encode(
+                &mut data_out,
+                &Content::Text(text.to_string()),
+                tag::Id3v24,
+                *encoding,
+            )
+            .unwrap();
+            assert_eq!(data, data_out);
+        }
+    }
+
+    #[test]
+    fn test_non_null_terminated_text_v4() {
+        assert!(decode("TRCK", tag::Id3v24, &[][..]).is_err());
+        let text = "text\u{0}text";
+        for encoding in &[
+            Encoding::Latin1,
+            Encoding::UTF8,
+            Encoding::UTF16,
+            Encoding::UTF16BE,
+        ] {
+            println!("`{}`, `{:?}`", text, encoding);
+            let mut data = Vec::new();
+            data.push(*encoding as u8);
+            data.extend(bytes_for_encoding(text, *encoding).into_iter());
 
             assert_eq!(
                 decode("TALB", tag::Id3v24, &data[..])

--- a/src/stream/frame/content.rs
+++ b/src/stream/frame/content.rs
@@ -425,11 +425,10 @@ macro_rules! decode_part {
         }
     }};
     ($bytes:expr, $params:ident, text_v4()) => {{
-        let (end, with_delim) =
-            match crate::util::find_last_delim($params.encoding, $bytes, $bytes.len() - 1) {
-                Some(i) => (i, i + delim_len($params.encoding)),
-                None => ($bytes.len(), $bytes.len()),
-            };
+        let (end, with_delim) = match crate::util::find_closing_delim($params.encoding, $bytes) {
+            Some(i) => (i, i + delim_len($params.encoding)),
+            None => ($bytes.len(), $bytes.len()),
+        };
         if end == 0 {
             ("".to_string(), &$bytes[with_delim..])
         } else {

--- a/src/stream/frame/content.rs
+++ b/src/stream/frame/content.rs
@@ -48,7 +48,11 @@ pub fn encode(
 }
 
 /// Attempts to decode the request.
-pub fn decode(id: &str, mut reader: impl io::Read) -> crate::Result<Content> {
+pub fn decode(
+    id: &str,
+    version: tag::Version,
+    mut reader: impl io::Read,
+) -> crate::Result<Content> {
     let mut data = Vec::new();
     reader.read_to_end(&mut data)?;
     match id {
@@ -60,9 +64,9 @@ pub fn decode(id: &str, mut reader: impl io::Read) -> crate::Result<Content> {
         "USLT" | "ULT" => parse_uslt(data.as_slice()),
         "SYLT" | "SLT" => parse_sylt(data.as_slice()),
         "GEOB" | "GEO" => parse_geob(data.as_slice()),
-        id if id.starts_with('T') => parse_text(data.as_slice()),
+        id if id.starts_with('T') => parse_text(data.as_slice(), version),
         id if id.starts_with('W') => parse_weblink(data.as_slice()),
-        "GRP1" => parse_text(data.as_slice()),
+        "GRP1" => parse_text(data.as_slice(), version),
         _ => Ok(Content::Unknown(data)),
     }
 }
@@ -406,11 +410,26 @@ macro_rules! decode_part {
             )
         }
     }};
-    ($bytes:expr, $params:ident, text()) => {{
+    ($bytes:expr, $params:ident, text_v3()) => {{
         let (end, with_delim) = match crate::util::find_delim($params.encoding, $bytes, 0) {
             Some(i) => (i, i + delim_len($params.encoding)),
             None => ($bytes.len(), $bytes.len()),
         };
+        if end == 0 {
+            ("".to_string(), &$bytes[with_delim..])
+        } else {
+            (
+                ($params.string_func)(&$bytes[..end])?,
+                &$bytes[with_delim..],
+            )
+        }
+    }};
+    ($bytes:expr, $params:ident, text_v4()) => {{
+        let (end, with_delim) =
+            match crate::util::find_last_delim($params.encoding, $bytes, $bytes.len() - 1) {
+                Some(i) => (i, i + delim_len($params.encoding)),
+                None => ($bytes.len(), $bytes.len()),
+            };
         if end == 0 {
             ("".to_string(), &$bytes[with_delim..])
         } else {
@@ -545,12 +564,15 @@ fn parse_comm(data: &[u8]) -> crate::Result<Content> {
 
 /// Attempts to parse the data as a text frame.
 /// Returns a `Content::Text`.
-fn parse_text(data: &[u8]) -> crate::Result<Content> {
+fn parse_text(data: &[u8], version: tag::Version) -> crate::Result<Content> {
     assert_data!(data);
     let encoding = encoding_from_byte(data[0])?;
 
     let params = DecodingParams::for_encoding(encoding);
-    Ok(Content::Text(decode_part!(&data[1..], params, text()).0))
+    match version {
+        tag::Version::Id3v24 => Ok(Content::Text(decode_part!(&data[1..], params, text_v4()).0)),
+        _ => Ok(Content::Text(decode_part!(&data[1..], params, text_v3()).0)),
+    }
 }
 
 /// Attempts to parse the data as a user defined text frame.
@@ -707,7 +729,7 @@ mod tests {
 
     #[test]
     fn test_apic_v2() {
-        assert!(decode("PIC", &[][..]).is_err());
+        assert!(decode("PIC", tag::Id3v22, &[][..]).is_err());
 
         let mut format_map = HashMap::new();
         format_map.insert("image/jpeg", "JPG");
@@ -735,7 +757,10 @@ mod tests {
                     data.extend(picture_data.iter().cloned());
 
                     assert_eq!(
-                        *decode("PIC", &data[..]).unwrap().picture().unwrap(),
+                        *decode("PIC", tag::Id3v22, &data[..])
+                            .unwrap()
+                            .picture()
+                            .unwrap(),
                         picture
                     );
                     let mut data_out = Vec::new();
@@ -754,7 +779,7 @@ mod tests {
 
     #[test]
     fn test_apic_v3() {
-        assert!(decode("APIC", &[][..]).is_err());
+        assert!(decode("APIC", tag::Id3v23, &[][..]).is_err());
 
         for mime_type in &["", "image/jpeg"] {
             for description in &["", "description"] {
@@ -784,7 +809,10 @@ mod tests {
                     data.extend(picture_data.iter().cloned());
 
                     assert_eq!(
-                        *decode("APIC", &data[..]).unwrap().picture().unwrap(),
+                        *decode("APIC", tag::Id3v23, &data[..])
+                            .unwrap()
+                            .picture()
+                            .unwrap(),
                         picture
                     );
                     let mut data_out = Vec::new();
@@ -803,7 +831,7 @@ mod tests {
 
     #[test]
     fn test_comm() {
-        assert!(decode("COMM", &[][..]).is_err());
+        assert!(decode("COMM", tag::Id3v23, &[][..]).is_err());
 
         println!("valid");
         for description in &["", "description"] {
@@ -828,7 +856,10 @@ mod tests {
                         text: comment.to_string(),
                     };
                     assert_eq!(
-                        *decode("COMM", &data[..]).unwrap().comment().unwrap(),
+                        *decode("COMM", tag::Id3v23, &data[..])
+                            .unwrap()
+                            .comment()
+                            .unwrap(),
                         content
                     );
                     let mut data_out = Vec::new();
@@ -859,7 +890,7 @@ mod tests {
             data.extend(b"eng".iter().cloned());
             data.extend(bytes_for_encoding(description, *encoding).into_iter());
             data.extend(bytes_for_encoding(comment, *encoding).into_iter());
-            assert!(decode("COMM", &data[..]).is_err());
+            assert!(decode("COMM", tag::Id3v23, &data[..]).is_err());
         }
         println!("Empty description");
         let comment = "comment";
@@ -883,7 +914,10 @@ mod tests {
             println!("data == {:?}", data);
             println!("content == {:?}", content);
             assert_eq!(
-                *decode("COMM", &data[..]).unwrap().comment().unwrap(),
+                *decode("COMM", tag::Id3v23, &data[..])
+                    .unwrap()
+                    .comment()
+                    .unwrap(),
                 content
             );
         }
@@ -891,7 +925,7 @@ mod tests {
 
     #[test]
     fn test_text() {
-        assert!(decode("TALB", &[][..]).is_err());
+        assert!(decode("TALB", tag::Id3v23, &[][..]).is_err());
 
         for text in &["", "text"] {
             for encoding in &[
@@ -905,7 +939,13 @@ mod tests {
                 data.push(*encoding as u8);
                 data.extend(bytes_for_encoding(text, *encoding).into_iter());
 
-                assert_eq!(decode("TALB", &data[..]).unwrap().text().unwrap(), *text);
+                assert_eq!(
+                    decode("TALB", tag::Id3v23, &data[..])
+                        .unwrap()
+                        .text()
+                        .unwrap(),
+                    *text
+                );
                 let mut data_out = Vec::new();
                 encode(
                     &mut data_out,
@@ -920,9 +960,9 @@ mod tests {
     }
 
     #[test]
-    fn test_null_terminated_text() {
-        assert!(decode("TRCK", &[][..]).is_err());
-        let text = "text\u{0}\u{0}";
+    fn test_null_terminated_text_v3() {
+        assert!(decode("TRCK", tag::Id3v23, &[][..]).is_err());
+        let text = "text\u{0}test\u{0}";
         for encoding in &[
             Encoding::Latin1,
             Encoding::UTF8,
@@ -934,7 +974,13 @@ mod tests {
             data.push(*encoding as u8);
             data.extend(bytes_for_encoding(text, *encoding).into_iter());
 
-            assert_eq!(decode("TALB", &data[..]).unwrap().text().unwrap(), "text");
+            assert_eq!(
+                decode("TALB", tag::Id3v23, &data[..])
+                    .unwrap()
+                    .text()
+                    .unwrap(),
+                "text"
+            );
             let mut data_out = Vec::new();
             encode(
                 &mut data_out,
@@ -948,8 +994,43 @@ mod tests {
     }
 
     #[test]
+    fn test_null_terminated_text_v4() {
+        assert!(decode("TRCK", tag::Id3v24, &[][..]).is_err());
+        let text = "text\u{0}text\u{0}";
+        for encoding in &[
+            Encoding::Latin1,
+            Encoding::UTF8,
+            Encoding::UTF16,
+            Encoding::UTF16BE,
+        ] {
+            println!("`{}`, `{:?}`", text, encoding);
+            let mut data = Vec::new();
+            data.push(*encoding as u8);
+            data.extend(bytes_for_encoding(text, *encoding).into_iter());
+            println!("bytes: {:?}", data);
+
+            assert_eq!(
+                decode("TALB", tag::Id3v24, &data[..])
+                    .unwrap()
+                    .text()
+                    .unwrap(),
+                "text\u{0}text"
+            );
+            let mut data_out = Vec::new();
+            encode(
+                &mut data_out,
+                &Content::Text(text.to_string()),
+                tag::Id3v24,
+                *encoding,
+            )
+            .unwrap();
+            assert_eq!(data, data_out);
+        }
+    }
+
+    #[test]
     fn test_txxx() {
-        assert!(decode("TXXX", &[][..]).is_err());
+        assert!(decode("TXXX", tag::Id3v23, &[][..]).is_err());
 
         println!("valid");
         for key in &["", "key"] {
@@ -972,7 +1053,10 @@ mod tests {
                         value: value.to_string(),
                     };
                     assert_eq!(
-                        *decode("TXXX", &data[..]).unwrap().extended_text().unwrap(),
+                        *decode("TXXX", tag::Id3v23, &data[..])
+                            .unwrap()
+                            .extended_text()
+                            .unwrap(),
                         content
                     );
                     let mut data_out = Vec::new();
@@ -1002,7 +1086,7 @@ mod tests {
             data.push(*encoding as u8);
             data.extend(bytes_for_encoding(key, *encoding).into_iter());
             data.extend(bytes_for_encoding(value, *encoding).into_iter());
-            assert!(decode("TXXX", &data[..]).is_err());
+            assert!(decode("TXXX", tag::Id3v23, &data[..]).is_err());
         }
     }
 
@@ -1012,7 +1096,13 @@ mod tests {
             println!("`{:?}`", link);
             let data = link.as_bytes().to_vec();
 
-            assert_eq!(decode("WOAF", &data[..]).unwrap().link().unwrap(), *link);
+            assert_eq!(
+                decode("WOAF", tag::Id3v23, &data[..])
+                    .unwrap()
+                    .link()
+                    .unwrap(),
+                *link
+            );
             let mut data_out = Vec::new();
             encode(
                 &mut data_out,
@@ -1027,7 +1117,7 @@ mod tests {
 
     #[test]
     fn test_wxxx() {
-        assert!(decode("WXXX", &[][..]).is_err());
+        assert!(decode("WXXX", tag::Id3v23, &[][..]).is_err());
 
         println!("valid");
         for description in &["", "rust"] {
@@ -1050,7 +1140,10 @@ mod tests {
                         link: link.to_string(),
                     };
                     assert_eq!(
-                        *decode("WXXX", &data[..]).unwrap().extended_link().unwrap(),
+                        *decode("WXXX", tag::Id3v23, &data[..])
+                            .unwrap()
+                            .extended_link()
+                            .unwrap(),
                         content
                     );
                     let mut data_out = Vec::new();
@@ -1080,13 +1173,13 @@ mod tests {
             data.push(*encoding as u8);
             data.extend(bytes_for_encoding(description, *encoding).into_iter());
             data.extend(bytes_for_encoding(link, Encoding::Latin1).into_iter());
-            assert!(decode("WXXX", &data[..]).is_err());
+            assert!(decode("WXXX", tag::Id3v23, &data[..]).is_err());
         }
     }
 
     #[test]
     fn test_uslt() {
-        assert!(decode("USLT", &[][..]).is_err());
+        assert!(decode("USLT", tag::Id3v23, &[][..]).is_err());
 
         println!("valid");
         for description in &["", "description"] {
@@ -1111,7 +1204,10 @@ mod tests {
                         text: text.to_string(),
                     };
                     assert_eq!(
-                        *decode("USLT", &data[..]).unwrap().lyrics().unwrap(),
+                        *decode("USLT", tag::Id3v23, &data[..])
+                            .unwrap()
+                            .lyrics()
+                            .unwrap(),
                         content
                     );
                     let mut data_out = Vec::new();
@@ -1142,7 +1238,7 @@ mod tests {
             data.extend(b"eng".iter().cloned());
             data.extend(bytes_for_encoding(description, *encoding).into_iter());
             data.extend(bytes_for_encoding(lyrics, *encoding).into_iter());
-            assert!(decode("USLT", &data[..]).is_err());
+            assert!(decode("USLT", tag::Id3v23, &data[..]).is_err());
         }
     }
 }

--- a/src/stream/frame/mod.rs
+++ b/src/stream/frame/mod.rs
@@ -24,6 +24,7 @@ pub fn decode(
 
 pub fn decode_content(
     reader: impl io::Read,
+    version: tag::Version,
     id: &str,
     compression: bool,
     unsynchronisation: bool,
@@ -31,14 +32,14 @@ pub fn decode_content(
     let result = if unsynchronisation {
         let reader_unsynch = unsynch::Reader::new(reader);
         if compression {
-            content::decode(id, ZlibDecoder::new(reader_unsynch))
+            content::decode(id, version, ZlibDecoder::new(reader_unsynch))
         } else {
-            content::decode(id, reader_unsynch)
+            content::decode(id, version, reader_unsynch)
         }
     } else if compression {
-        content::decode(id, ZlibDecoder::new(reader))
+        content::decode(id, version, ZlibDecoder::new(reader))
     } else {
-        content::decode(id, reader)
+        content::decode(id, version, reader)
     };
     Ok(result?)
 }
@@ -109,7 +110,7 @@ mod tests {
         data.push(encoding as u8);
         data.extend(string_to_utf16(text).into_iter());
 
-        let content = decode_content(&data[..], id, false, false).unwrap();
+        let content = decode_content(&data[..], tag::Id3v22, id, false, false).unwrap();
         let frame = Frame::with_content(id, content);
 
         let mut bytes = Vec::new();
@@ -132,7 +133,7 @@ mod tests {
         data.push(encoding as u8);
         data.extend(string_to_utf16(text).into_iter());
 
-        let content = decode_content(&data[..], id, false, false).unwrap();
+        let content = decode_content(&data[..], tag::Id3v23, id, false, false).unwrap();
         let frame = Frame::with_content(id, content);
 
         let mut bytes = Vec::new();
@@ -156,7 +157,7 @@ mod tests {
         data.push(encoding as u8);
         data.extend(text.bytes());
 
-        let content = decode_content(&data[..], id, false, false).unwrap();
+        let content = decode_content(&data[..], tag::Id3v24, id, false, false).unwrap();
         let mut frame = Frame::with_content(id, content);
         frame.set_tag_alter_preservation(true);
         frame.set_file_alter_preservation(true);

--- a/src/stream/frame/v2.rs
+++ b/src/stream/frame/v2.rs
@@ -17,7 +17,7 @@ pub fn decode(mut reader: impl io::Read) -> crate::Result<Option<(usize, Frame)>
     let sizebytes = &frame_header[3..6];
     let read_size =
         (u32::from(sizebytes[0]) << 16) | (u32::from(sizebytes[1]) << 8) | u32::from(sizebytes[2]);
-    let content = super::content::decode(id, reader.take(u64::from(read_size)))?;
+    let content = super::content::decode(id, tag::Id3v22, reader.take(u64::from(read_size)))?;
     let frame = Frame::with_content(id, content);
     Ok(Some((6 + read_size as usize, frame)))
 }

--- a/src/stream/frame/v3.rs
+++ b/src/stream/frame/v3.rs
@@ -56,6 +56,7 @@ pub fn decode(
     };
     let content = super::decode_content(
         reader.take(read_size as u64),
+        tag::Id3v23,
         id,
         flags.contains(Flags::COMPRESSION),
         unsynchronisation,

--- a/src/stream/frame/v4.rs
+++ b/src/stream/frame/v4.rs
@@ -55,6 +55,7 @@ pub fn decode(mut reader: impl io::Read) -> crate::Result<Option<(usize, Frame)>
 
     let content = super::decode_content(
         reader.take(read_size as u64),
+        tag::Id3v24,
         id,
         flags.contains(Flags::COMPRESSION),
         flags.contains(Flags::UNSYNCHRONISATION),

--- a/src/util.rs
+++ b/src/util.rs
@@ -103,26 +103,33 @@ pub fn string_to_utf16le(text: &str) -> Vec<u8> {
 }
 
 /// Returns the index of the last delimiter for the specified encoding.
-pub fn find_last_delim(encoding: Encoding, data: &[u8], index: usize) -> Option<usize> {
-    let mut i = index;
-    if i >= data.len() {
-        return None;
-    }
+pub fn find_closing_delim(encoding: Encoding, data: &[u8]) -> Option<usize> {
+    let mut i = data.len();
     match encoding {
         Encoding::Latin1 | Encoding::UTF8 => {
+            i = i.checked_sub(1)?;
             while i > 0 {
-                if data[i] == 0 {
-                    return Some(i);
+                if data[i] != 0 {
+                    return if (i + 1) == data.len() {
+                        None
+                    } else {
+                        Some(i + 1)
+                    };
                 }
                 i -= 1;
             }
             None
         }
         Encoding::UTF16 | Encoding::UTF16BE => {
+            i = i.checked_sub(2)?;
             i -= i % 2; // align to 2-byte boundary
             while i > 1 {
-                if data[i] == 0 && data[i + 1] == 0 {
-                    return Some(i);
+                if data[i] != 0 || data[i + 1] != 0 {
+                    return if (i + 2) == data.len() {
+                        None
+                    } else {
+                        Some(i + 2)
+                    };
                 }
                 i -= 2;
             }


### PR DESCRIPTION
This PR implements a way to correctly handle ID3v2.4 text frames. All text frames in ID3v2.4 may contain multiple values separated by null bytes, of which only the first value is returned by the current implementation.

A new test case was added to test this behaviour: `id3::stream::frame::content::tests::test_null_terminated_text_v4` tests that `text\0text\0` will be decoded to `text\0text` keeping the null byte for ID3v2.4 tags.

I have tried to keep breakage to a minimum, thus I have not added a new `Content` variant but instead opted to use the existing `Text` variant with a new function that splits the contained text into its separate values.

See also #20.