### PR TITLE
Save ID3v2 version

### DIFF
--- a/src/stream/tag.rs
+++ b/src/stream/tag.rs
@@ -124,7 +124,7 @@ pub fn decode(mut reader: impl io::Read) -> crate::Result<Tag> {
         }
     } else {
         let mut offset = 0;
-        let mut tag = Tag::new();
+        let mut tag = Tag::with_version(header.version);
         while offset < header.frame_bytes() {
             let rs = frame::decode(
                 &mut reader,
@@ -147,7 +147,7 @@ pub fn decode(mut reader: impl io::Read) -> crate::Result<Tag> {
 }
 
 pub fn decode_v2_frames(mut reader: impl io::Read) -> crate::Result<Tag> {
-    let mut tag = Tag::new();
+    let mut tag = Tag::with_version(Version::Id3v22);
     // Add all frames, until either an error is thrown or there are no more frames to parse
     // (because of EOF or a Padding).
     loop {

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -42,17 +42,37 @@ impl Version {
     }
 }
 
+impl Default for Version {
+    fn default() -> Self {
+        Version::Id3v24
+    }
+}
+
 /// An ID3 tag containing metadata frames.
 #[derive(Clone, Debug, Default, Eq)]
 pub struct Tag {
     /// A vector of frames included in the tag.
     frames: Vec<Frame>,
+    /// ID3 Tag version
+    version: Version,
 }
 
 impl<'a> Tag {
     /// Creates a new ID3v2.4 tag with no frames.
     pub fn new() -> Tag {
         Tag::default()
+    }
+
+    /// Used for creating new tag with version
+    pub fn with_version(version: Version) -> Tag {
+        let mut tag = Tag::default();
+        tag.version = version;
+        tag
+    }
+
+    /// Returns version of the read tag
+    pub fn version(&self) -> Version {
+        self.version
     }
 
     /// Returns an iterator over the all frames in the tag.
@@ -1831,5 +1851,27 @@ mod tests {
         file.read_exact(&mut trailing_data).unwrap();
 
         assert_eq!(&trailing_data, data)
+    }
+
+    #[test]
+    fn check_read_version() {
+        assert_eq!(
+            Tag::read_from_path("testdata/id3v22.id3")
+                .unwrap()
+                .version(),
+            Version::Id3v22
+        );
+        assert_eq!(
+            Tag::read_from_path("testdata/id3v23.id3")
+                .unwrap()
+                .version(),
+            Version::Id3v23
+        );
+        assert_eq!(
+            Tag::read_from_path("testdata/id3v24.id3")
+                .unwrap()
+                .version(),
+            Version::Id3v24
+        );
     }
 }


### PR DESCRIPTION
Hello, in this commit, ID3v2 version gets saved into `Tag`, and can be later retrieved using `.version()`. This is useful, if you want to read tag, and save with the same version. I also have idea changing the `write_to` functions, and make version an `Option<Version>`, however that would break the API so I didn't implement that. 

Thank you.