### PR TITLE
Fix encoding of synchronized lyrics

### DIFF
--- a/src/stream/frame/content.rs
+++ b/src/stream/frame/content.rs
@@ -228,7 +228,7 @@ fn synchronised_lyrics_to_bytes(request: EncoderRequest) -> Vec<u8> {
         params,
         byte(match encoding {
             Encoding::Latin1 => 0,
-            Encoding::UTF8 => 1,
+            Encoding::UTF8 => 3,
             _ => unreachable!(),
         })
     );

--- a/src/stream/frame/content.rs
+++ b/src/stream/frame/content.rs
@@ -203,7 +203,7 @@ fn synchronised_lyrics_to_bytes(request: EncoderRequest) -> Vec<u8> {
     };
     let text_delim: &[u8] = match encoding {
         Encoding::Latin1 => &[0],
-        Encoding::UTF8 => &[0, 0],
+        Encoding::UTF8 => &[0],
         _ => unreachable!(),
     };
 
@@ -216,7 +216,7 @@ fn synchronised_lyrics_to_bytes(request: EncoderRequest) -> Vec<u8> {
         },
         Encoding::UTF8 => EncodingParams {
             // UTF-8
-            delim_len: 2,
+            delim_len: 1,
             string_func: Box::new(|buf: &mut Vec<u8>, string: &str| buf.extend(string.bytes())),
         },
         _ => unreachable!(),
@@ -248,8 +248,8 @@ fn synchronised_lyrics_to_bytes(request: EncoderRequest) -> Vec<u8> {
         buf,
         params,
         byte(match content.timestamp_format {
-            TimestampFormat::MPEG => 0,
-            TimestampFormat::MS => 1,
+            TimestampFormat::MPEG => 1,
+            TimestampFormat::MS => 2,
         })
     );
     encode_part!(

--- a/src/stream/frame/content.rs
+++ b/src/stream/frame/content.rs
@@ -265,6 +265,10 @@ fn synchronised_lyrics_to_bytes(request: EncoderRequest) -> Vec<u8> {
             SynchronisedLyricsType::Trivia => 6,
         })
     );
+    // TODO: content descriptor would go here
+    // instead we write an empty descriptor
+    encode_part!(buf, params, bytes(text_delim));
+
     for (timestamp, text) in &content.content {
         encode_part!(buf, params, string(text));
         encode_part!(buf, params, bytes(text_delim));


### PR DESCRIPTION
Hi, thanks for the lib!
I kept getting garbled output (in the form of CJK characters) when writing SYLT frames so I compared the output of
```rust
    let mut tag = Tag::new();
    let slt = SynchronisedLyrics {
        lang: "eng".into(),
        timestamp_format: TimestampFormat::MS,
        content_type: SynchronisedLyricsType::Lyrics,
        content: vec![
            (0, "ten".into()),
            (1000, "nine".into()),
            (2000, "eight".into()),
            (3000, "seven".into()),
            (4000, "six".into()),
            (5000, "5".into()),
            (6000, "4".into()),
            (7000, "3".into()),
            (8000, "2".into()),
            (9000, "1".into()),
            (10000, "0".into()),
            (11000, "".into()),
        ],
    };
    slt.fmt_table(io::stdout())?;
    tag.add_synchronised_lyrics(slt);
    tag.set_artist("cweiske");
    tag.set_title("Countdown aligned");
    tag.write_to_path("testdata/countdown.mp3", Version::Id3v24)?;
```
with `countdown-sync-kid3-id3v2.4.mp3` from https://cweiske.de/tagebuch/embedded-lyrics.htm#demo in a hex editor, and found a couple things that didn't align with the spec.
With these changes, I get matching output using `kid3-cli -c "get SYLT:/dev/stdout" testdata/countdown.mp3`, and `exiftool` displays the synchronized lyrics correctly as well. I tested all 3 versions of id3 that the library supports.

I linked the relevant parts of the spec in the body of each commit message.