### PR TITLE
Fix SYLT

### DIFF
--- a/src/stream/frame/content.rs
+++ b/src/stream/frame/content.rs
@@ -248,8 +248,8 @@ fn synchronised_lyrics_to_bytes(request: EncoderRequest) -> Vec<u8> {
         buf,
         params,
         byte(match content.timestamp_format {
-            TimestampFormat::MPEG => 0,
-            TimestampFormat::MS => 1,
+            TimestampFormat::MPEG => 1,
+            TimestampFormat::MS => 2,
         })
     );
     encode_part!(
@@ -655,8 +655,8 @@ fn parse_sylt(data: &[u8]) -> crate::Result<Content> {
 
     let (lang, next) = decode_part!(next, params, fixed_string(3));
     let timestamp_format = match next[0] {
-        0 => TimestampFormat::MPEG,
-        1 => TimestampFormat::MS,
+        1 => TimestampFormat::MPEG,
+        2 => TimestampFormat::MS,
         _ => {
             return Err(Error::new(
                 ErrorKind::Parsing,


### PR DESCRIPTION
Hello, according to the ID3 spec https://id3.org/id3v2.3.0#sec4.10 - the timestamp format has values 1 and 2, rather than 0 and 1.

Relevant part:
```
$01 Absolute time, 32 bit sized, using MPEG frames as unit
$02 Absolute time, 32 bit sized, using milliseconds as unit
```

Thank you.