### PR TITLE
feat: Add an `encode` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,14 @@ include = ["src/*", "Cargo.toml", "LICENSE", "README.md"]
 bitflags = "1.3"
 byteorder = "1.4"
 flate2 = "1"
+document-features = "0.2"
 
 [dev-dependencies]
 tempfile = "3"
+
+[features]
+default = ["encode"]
+
+## Support encoding ID3 tags
+encode = []
+

--- a/src/frame/mod.rs
+++ b/src/frame/mod.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "encode")]
 use crate::error::{Error, ErrorKind};
 use crate::stream::encoding::Encoding;
 use crate::tag::Version;
@@ -47,6 +48,7 @@ impl Frame {
                 || self.encoding == other.encoding)
     }
 
+    #[cfg(feature = "encode")]
     pub(crate) fn validate(&self) -> crate::Result<()> {
         // The valid/invalid ID enum exists to be able to read and write back unknown and possibly
         // invalid IDs. If it can be read, it can also be written again.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,6 @@
 #![doc = include_str!("../README.md")]
+//! ## Crate feature flags
+#![doc = document_features::document_features!()]
 #![deny(missing_docs)]
 #![deny(clippy::all)]
 
@@ -9,7 +11,9 @@
 
 pub use crate::error::{partial_tag_ok, Error, ErrorKind, Result};
 pub use crate::frame::{Content, Frame, Timestamp};
+#[cfg(feature = "encode")]
 pub use crate::stream::encoding::Encoding;
+#[cfg(feature = "encode")]
 pub use crate::stream::tag::Encoder;
 pub use crate::tag::{Tag, Version};
 pub use crate::taglike::TagLike;

--- a/src/stream/tag.rs
+++ b/src/stream/tag.rs
@@ -1,16 +1,22 @@
-use crate::storage::{PlainStorage, Storage};
 use crate::stream::{frame, unsynch};
 use crate::tag::{Tag, Version};
 use crate::taglike::TagLike;
 use crate::{Error, ErrorKind};
 use bitflags::bitflags;
-use byteorder::{BigEndian, ByteOrder, WriteBytesExt};
+use byteorder::{BigEndian, ByteOrder};
 use std::cmp;
-use std::fs;
-use std::io::{self, Read, Write};
+use std::io::{self, Read};
 use std::ops::Range;
-use std::path::Path;
+#[cfg(feature = "encode")]
+use {
+    crate::storage::{PlainStorage, Storage},
+    byteorder::WriteBytesExt,
+    std::fs,
+    std::io::Write,
+    std::path::Path,
+};
 
+#[cfg(feature = "encode")]
 static DEFAULT_FILE_DISCARD: &[&str] = &[
     "AENC", "ETCO", "EQUA", "MLLT", "POSS", "SYLT", "SYTC", "RVAD", "TENC", "TLEN", "TSIZ",
 ];
@@ -207,6 +213,7 @@ pub fn decode_v2_frames(mut reader: impl io::Read) -> crate::Result<Tag> {
 
 /// The `Encoder` may be used to encode tags with custom settings.
 #[derive(Clone, Debug)]
+#[cfg(feature = "encode")]
 pub struct Encoder {
     version: Version,
     unsynchronisation: bool,
@@ -215,6 +222,7 @@ pub struct Encoder {
     padding: Option<usize>,
 }
 
+#[cfg(feature = "encode")]
 impl Encoder {
     /// Constructs a new `Encoder` with the following configuration:
     ///
@@ -344,6 +352,7 @@ impl Encoder {
     }
 }
 
+#[cfg(feature = "encode")]
 impl Default for Encoder {
     fn default() -> Self {
         Self::new()

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -3,15 +3,20 @@ use crate::frame::{
     Chapter, Comment, EncapsulatedObject, ExtendedLink, ExtendedText, Frame, Lyrics, Picture,
     SynchronisedLyrics,
 };
-use crate::storage::{PlainStorage, Storage};
 use crate::stream;
 use crate::taglike::TagLike;
 use crate::v1;
 use std::fmt;
 use std::fs::{self, File};
-use std::io::{self, BufReader, Write};
+use std::io::{self, BufReader};
 use std::iter::{FromIterator, Iterator};
 use std::path::Path;
+
+#[cfg(feature = "encode")]
+use {
+    crate::storage::{PlainStorage, Storage},
+    std::io::Write,
+};
 
 /// Denotes the version of a tag.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
@@ -108,6 +113,7 @@ impl<'a> Tag {
     /// Removes an ID3v2 tag from the file at the specified path.
     ///
     /// Returns true if the file initially contained a tag.
+    #[cfg(feature = "encode")]
     pub fn remove_from_path(path: impl AsRef<Path>) -> crate::Result<bool> {
         let mut file = fs::OpenOptions::new()
             .read(true)
@@ -121,6 +127,7 @@ impl<'a> Tag {
     /// Removes an ID3v2 tag from the specified file.
     ///
     /// Returns true if the file initially contained a tag.
+    #[cfg(feature = "encode")]
     pub fn remove_from_file(mut file: &mut fs::File) -> crate::Result<bool> {
         let location = match stream::tag::locate_id3v2(&mut file)? {
             Some(l) => l,
@@ -180,6 +187,7 @@ impl<'a> Tag {
     ///
     /// Note that the plain tag is written, regardless of the original contents. To safely encode a
     /// tag to an MP3 file, use `Tag::write_to_path`.
+    #[cfg(feature = "encode")]
     pub fn write_to(&self, writer: impl io::Write, version: Version) -> crate::Result<()> {
         stream::tag::Encoder::new()
             .version(version)
@@ -189,6 +197,7 @@ impl<'a> Tag {
     /// Attempts to write the ID3 tag from the file at the indicated path. If the specified path is
     /// the same path which the tag was read from, then the tag will be written to the padding if
     /// possible.
+    #[cfg(feature = "encode")]
     pub fn write_to_path(&self, path: impl AsRef<Path>, version: Version) -> crate::Result<()> {
         let mut file = fs::OpenOptions::new().read(true).write(true).open(path)?;
         #[allow(clippy::reversed_empty_ranges)]
@@ -204,6 +213,7 @@ impl<'a> Tag {
     }
 
     /// Overwrite WAV file ID3 chunk in a file
+    #[cfg(feature = "encode")]
     pub fn write_to_aiff_path(
         &self,
         path: impl AsRef<Path>,
@@ -221,11 +231,13 @@ impl<'a> Tag {
     }
 
     /// Overwrite AIFF file ID3 chunk in a file. The file must be opened read/write.
+    #[cfg(feature = "encode")]
     pub fn write_to_aiff_file(&self, file: &mut fs::File, version: Version) -> crate::Result<()> {
         chunk::write_id3_chunk_file::<chunk::AiffFormat>(file, self, version)
     }
 
     /// Overwrite WAV file ID3 chunk
+    #[cfg(feature = "encode")]
     pub fn write_to_wav_path(&self, path: impl AsRef<Path>, version: Version) -> crate::Result<()> {
         let mut file = fs::OpenOptions::new()
             .read(true)
@@ -239,6 +251,7 @@ impl<'a> Tag {
     }
 
     /// Overwrite AIFF file ID3 chunk in a file. The file must be opened read/write.
+    #[cfg(feature = "encode")]
     pub fn write_to_wav_file(&self, file: &mut fs::File, version: Version) -> crate::Result<()> {
         chunk::write_id3_chunk_file::<chunk::WavFormat>(file, self, version)
     }

--- a/src/v1v2.rs
+++ b/src/v1v2.rs
@@ -1,4 +1,4 @@
-use crate::{v1, Error, ErrorKind, Tag, Version};
+use crate::{v1, Error, ErrorKind, Tag};
 use std::fs::File;
 use std::path::Path;
 
@@ -48,7 +48,12 @@ pub fn read_from_path(path: impl AsRef<Path>) -> crate::Result<Tag> {
 ///
 /// If any ID3v1 tag is present it will be REMOVED as it is not able to fully represent a ID3v2
 /// tag.
-pub fn write_to_path(path: impl AsRef<Path>, tag: &Tag, version: Version) -> crate::Result<()> {
+#[cfg(feature = "encode")]
+pub fn write_to_path(
+    path: impl AsRef<Path>,
+    tag: &Tag,
+    version: crate::Version,
+) -> crate::Result<()> {
     tag.write_to_path(&path, version)?;
     v1::Tag::remove_from_path(path)?;
     Ok(())
@@ -57,6 +62,7 @@ pub fn write_to_path(path: impl AsRef<Path>, tag: &Tag, version: Version) -> cra
 /// Ensures that both ID3v1 and ID3v2 are not present in the specified file.
 ///
 /// Returns [`FormatVersion`] representing the previous state.
+#[cfg(feature = "encode")]
 pub fn remove_from_path(path: impl AsRef<Path>) -> crate::Result<FormatVersion> {
     let v2 = Tag::remove_from_path(&path)?;
     let v1 = v1::Tag::remove_from_path(path)?;
@@ -135,7 +141,7 @@ mod tests {
 
         let mut tag = read_from_path(&tmp).unwrap();
         tag.set_artist("High Contrast");
-        write_to_path(&tmp, &tag, Version::Id3v24).unwrap();
+        write_to_path(&tmp, &tag, crate::Version::Id3v24).unwrap();
 
         assert_eq!(is_candidate_path(&tmp).unwrap(), FormatVersion::Id3v2);
     }


### PR DESCRIPTION
Encoding and decoding tags are fairly different usecases, so it makes sense to offer a slightly smaller library for people who only want to decode tags.

This commit adds an `encode` feature flag that's enabled by default, and puts the obvious `Tag` methods behind it.