### PR TITLE
Adds support for reading/writing TDOR frames

### DIFF
--- a/src/taglike.rs
+++ b/src/taglike.rs
@@ -333,6 +333,52 @@ pub trait TagLike: private::Sealed {
         self.remove("TDRL");
     }
 
+    /// Return the content of the TDOR frame, if any
+    ///
+    /// # Example
+    /// ```
+    /// use id3::{Tag, TagLike, Timestamp};
+    ///
+    /// let mut tag = Tag::new();
+    /// tag.set_original_date_released(Timestamp{ year: 2014, month: None, day: None, hour: None, minute: None, second: None });
+    /// assert_eq!(tag.original_date_released().map(|t| t.year), Some(2014));
+    /// ```
+    fn original_date_released(&self) -> Option<Timestamp> {
+        self.read_timestamp_frame("TDOR")
+    }
+
+    /// Sets the content of the TDOR frame
+    ///
+    /// # Example
+    /// ```
+    /// use id3::{Tag, TagLike, Timestamp};
+    ///
+    /// let mut tag = Tag::new();
+    /// tag.set_original_date_released(Timestamp{ year: 2014, month: None, day: None, hour: None, minute: None, second: None });
+    /// assert_eq!(tag.original_date_released().map(|t| t.year), Some(2014));
+    /// ```
+    fn set_original_date_released(&mut self, timestamp: Timestamp) {
+        let time_string = timestamp.to_string();
+        self.set_text("TDOR", time_string);
+    }
+
+    /// Remove the content of the TDOR frame
+    ///
+    /// # Example
+    /// ```
+    /// use id3::{Tag, TagLike, Timestamp};
+    ///
+    /// let mut tag = Tag::new();
+    /// tag.set_original_date_released(Timestamp{ year: 2014, month: None, day: None, hour: None, minute: None, second: None });
+    /// assert!(tag.original_date_released().is_some());
+    ///
+    /// tag.remove_original_date_released();
+    /// assert!(tag.original_date_released().is_none());
+    /// ```
+    fn remove_original_date_released(&mut self) {
+        self.remove("TDOR");
+    }
+
     /// Returns the artist (TPE1).
     ///
     /// # Example


### PR DESCRIPTION
This frame is a ID3v2.4 addition (similar to `TDRL`) which encodes Original Release Date.

I initially had a more ambitious version of this change handling upgrading from `TOR`/`TORY` frames, using logic similar to `convert_2_to_3_and_back`. However, if we stored `TOR`/`TORY` frames as `TDOR` for the in-memory representation, we would then have to ensure they get trimmed to only a year (without month, day, etc.) when encoding as a `2.3` or `2.2` tag. There is currently nowhere suitable to host this logic, so I trimmed the PR to direct manipulation of `TDOR` frames only.