### PR TITLE
Fix dropping of multiple frames with same id + small fix

### DIFF
--- a/src/frame/content.rs
+++ b/src/frame/content.rs
@@ -57,61 +57,32 @@ pub enum Content {
 }
 
 impl Content {
-    pub(crate) fn unique(&self, deeper: bool) -> impl PartialEq + '_ {
-        if deeper {
-            match self {
-                Self::Text(text) => Comparable(vec![Cow::Borrowed(text.as_bytes())]),
-                Self::ExtendedText(extended_text) => Comparable(vec![Cow::Borrowed(extended_text.description.as_bytes())]),
-                Self::Link(text) => Comparable(vec![Cow::Borrowed(text.as_bytes())]),
-                Self::ExtendedLink(extended_link) => Comparable(vec![Cow::Borrowed(extended_link.description.as_bytes())]),
-                Self::Popularimeter(popularimeter) => Comparable(vec![Cow::Borrowed(popularimeter.user.as_bytes())]),
-                Self::Comment(comment) => Comparable(vec![
-                    Cow::Borrowed(comment.lang.as_bytes()),
-                    Cow::Borrowed(comment.description.as_bytes()),
-                ]),
-                Self::Lyrics(lyrics) => Comparable(vec![
-                    Cow::Borrowed(lyrics.lang.as_bytes()),
-                    Cow::Borrowed(lyrics.description.as_bytes()),
-                ]),
-                Self::SynchronisedLyrics(synchronised_lyrics) => Comparable(vec![
-                    Cow::Borrowed(synchronised_lyrics.lang.as_bytes()),
-                    Cow::Owned(synchronised_lyrics.content_type.to_string().as_bytes().to_owned()),
-                ]),
-                Self::Picture(picture) => Comparable(vec![Cow::Owned(picture.picture_type.to_string().as_bytes().to_owned())]),
-                Self::EncapsulatedObject(encapsulated_object) => {
-                    Comparable(vec![Cow::Borrowed(encapsulated_object.description.as_bytes())])
-                }
-                Self::Chapter(chapter) => Comparable(vec![Cow::Borrowed(chapter.element_id.as_bytes())]),
-                Self::MpegLocationLookupTable(_) => Same,
-                Self::Unknown(_) => Incomparable,
+    pub(crate) fn unique(&self) -> impl PartialEq + '_ {
+        match self {
+            Self::Text(_) => Same,
+            Self::ExtendedText(extended_text) => Comparable(vec![Cow::Borrowed(extended_text.description.as_bytes())]),
+            Self::Link(_) => Same,
+            Self::ExtendedLink(extended_link) => Comparable(vec![Cow::Borrowed(extended_link.description.as_bytes())]),
+            Self::Popularimeter(popularimeter) => Comparable(vec![Cow::Borrowed(popularimeter.user.as_bytes())]),
+            Self::Comment(comment) => Comparable(vec![
+                Cow::Borrowed(comment.lang.as_bytes()),
+                Cow::Borrowed(comment.description.as_bytes()),
+            ]),
+            Self::Lyrics(lyrics) => Comparable(vec![
+                Cow::Borrowed(lyrics.lang.as_bytes()),
+                Cow::Borrowed(lyrics.description.as_bytes()),
+            ]),
+            Self::SynchronisedLyrics(synchronised_lyrics) => Comparable(vec![
+                Cow::Borrowed(synchronised_lyrics.lang.as_bytes()),
+                Cow::Owned(synchronised_lyrics.content_type.to_string().as_bytes().to_owned()),
+            ]),
+            Self::Picture(picture) => Comparable(vec![Cow::Owned(picture.picture_type.to_string().as_bytes().to_owned())]),
+            Self::EncapsulatedObject(encapsulated_object) => {
+                Comparable(vec![Cow::Borrowed(encapsulated_object.description.as_bytes())])
             }
-        } else {
-            match self {
-                Self::Text(_) => Same,
-                Self::ExtendedText(extended_text) => Comparable(vec![Cow::Borrowed(extended_text.description.as_bytes())]),
-                Self::Link(_) => Same,
-                Self::ExtendedLink(extended_link) => Comparable(vec![Cow::Borrowed(extended_link.description.as_bytes())]),
-                Self::Popularimeter(popularimeter) => Comparable(vec![Cow::Borrowed(popularimeter.user.as_bytes())]),
-                Self::Comment(comment) => Comparable(vec![
-                    Cow::Borrowed(comment.lang.as_bytes()),
-                    Cow::Borrowed(comment.description.as_bytes()),
-                ]),
-                Self::Lyrics(lyrics) => Comparable(vec![
-                    Cow::Borrowed(lyrics.lang.as_bytes()),
-                    Cow::Borrowed(lyrics.description.as_bytes()),
-                ]),
-                Self::SynchronisedLyrics(synchronised_lyrics) => Comparable(vec![
-                    Cow::Borrowed(synchronised_lyrics.lang.as_bytes()),
-                    Cow::Owned(synchronised_lyrics.content_type.to_string().as_bytes().to_owned()),
-                ]),
-                Self::Picture(picture) => Comparable(vec![Cow::Owned(picture.picture_type.to_string().as_bytes().to_owned())]),
-                Self::EncapsulatedObject(encapsulated_object) => {
-                    Comparable(vec![Cow::Borrowed(encapsulated_object.description.as_bytes())])
-                }
-                Self::Chapter(chapter) => Comparable(vec![Cow::Borrowed(chapter.element_id.as_bytes())]),
-                Self::MpegLocationLookupTable(_) => Same,
-                Self::Unknown(_) => Incomparable,
-            }
+            Self::Chapter(chapter) => Comparable(vec![Cow::Borrowed(chapter.element_id.as_bytes())]),
+            Self::MpegLocationLookupTable(_) => Same,
+            Self::Unknown(_) => Incomparable,
         }
     }
 

--- a/src/frame/content.rs
+++ b/src/frame/content.rs
@@ -56,32 +56,61 @@ pub enum Content {
 }
 
 impl Content {
-    pub(crate) fn unique(&self) -> impl Eq + '_ {
-        match self {
-            Self::Text(_) => Vec::new(),
-            Self::ExtendedText(extended_text) => vec![Cow::Borrowed(extended_text.description.as_bytes())],
-            Self::Link(_) => Vec::new(),
-            Self::ExtendedLink(extended_link) => vec![Cow::Borrowed(extended_link.description.as_bytes())],
-            Self::Popularimeter(popularimeter) => vec![Cow::Borrowed(popularimeter.user.as_bytes())],
-            Self::Comment(comment) => vec![
-                Cow::Borrowed(comment.lang.as_bytes()),
-                Cow::Borrowed(comment.description.as_bytes()),
-            ],
-            Self::Lyrics(lyrics) => vec![
-                Cow::Borrowed(lyrics.lang.as_bytes()),
-                Cow::Borrowed(lyrics.description.as_bytes()),
-            ],
-            Self::SynchronisedLyrics(synchronised_lyrics) => vec![
-                Cow::Borrowed(synchronised_lyrics.lang.as_bytes()),
-                Cow::Owned(synchronised_lyrics.content_type.to_string().as_bytes().to_owned()),
-            ],
-            Self::Picture(picture) => vec![Cow::Owned(picture.picture_type.to_string().as_bytes().to_owned())],
-            Self::EncapsulatedObject(encapsulated_object) => {
-                vec![Cow::Borrowed(encapsulated_object.description.as_bytes())]
+    pub(crate) fn unique(&self, deeper: bool) -> impl Eq + '_ {
+        if deeper {
+            match self {
+                Self::Text(text) => vec![Cow::Borrowed(text.as_bytes())],
+                Self::ExtendedText(extended_text) => vec![Cow::Borrowed(extended_text.description.as_bytes())],
+                Self::Link(text) => vec![Cow::Borrowed(text.as_bytes())],
+                Self::ExtendedLink(extended_link) => vec![Cow::Borrowed(extended_link.description.as_bytes())],
+                Self::Popularimeter(popularimeter) => vec![Cow::Borrowed(popularimeter.user.as_bytes())],
+                Self::Comment(comment) => vec![
+                    Cow::Borrowed(comment.lang.as_bytes()),
+                    Cow::Borrowed(comment.description.as_bytes()),
+                ],
+                Self::Lyrics(lyrics) => vec![
+                    Cow::Borrowed(lyrics.lang.as_bytes()),
+                    Cow::Borrowed(lyrics.description.as_bytes()),
+                ],
+                Self::SynchronisedLyrics(synchronised_lyrics) => vec![
+                    Cow::Borrowed(synchronised_lyrics.lang.as_bytes()),
+                    Cow::Owned(synchronised_lyrics.content_type.to_string().as_bytes().to_owned()),
+                ],
+                Self::Picture(picture) => vec![Cow::Owned(picture.picture_type.to_string().as_bytes().to_owned())],
+                Self::EncapsulatedObject(encapsulated_object) => {
+                    vec![Cow::Borrowed(encapsulated_object.description.as_bytes())]
+                }
+                Self::Chapter(chapter) => vec![Cow::Borrowed(chapter.element_id.as_bytes())],
+                Self::MpegLocationLookupTable(_) => Vec::new(),
+                Self::Unknown(unknown) => vec![Cow::Borrowed(unknown.data.as_slice())],
             }
-            Self::Chapter(chapter) => vec![Cow::Borrowed(chapter.element_id.as_bytes())],
-            Self::MpegLocationLookupTable(_) => Vec::new(),
-            Self::Unknown(unknown) => vec![Cow::Borrowed(unknown.data.as_slice())],
+        } else {
+            match self {
+                Self::Text(_) => Vec::new(),
+                Self::ExtendedText(extended_text) => vec![Cow::Borrowed(extended_text.description.as_bytes())],
+                Self::Link(_) => Vec::new(),
+                Self::ExtendedLink(extended_link) => vec![Cow::Borrowed(extended_link.description.as_bytes())],
+                Self::Popularimeter(popularimeter) => vec![Cow::Borrowed(popularimeter.user.as_bytes())],
+                Self::Comment(comment) => vec![
+                    Cow::Borrowed(comment.lang.as_bytes()),
+                    Cow::Borrowed(comment.description.as_bytes()),
+                ],
+                Self::Lyrics(lyrics) => vec![
+                    Cow::Borrowed(lyrics.lang.as_bytes()),
+                    Cow::Borrowed(lyrics.description.as_bytes()),
+                ],
+                Self::SynchronisedLyrics(synchronised_lyrics) => vec![
+                    Cow::Borrowed(synchronised_lyrics.lang.as_bytes()),
+                    Cow::Owned(synchronised_lyrics.content_type.to_string().as_bytes().to_owned()),
+                ],
+                Self::Picture(picture) => vec![Cow::Owned(picture.picture_type.to_string().as_bytes().to_owned())],
+                Self::EncapsulatedObject(encapsulated_object) => {
+                    vec![Cow::Borrowed(encapsulated_object.description.as_bytes())]
+                }
+                Self::Chapter(chapter) => vec![Cow::Borrowed(chapter.element_id.as_bytes())],
+                Self::MpegLocationLookupTable(_) => Vec::new(),
+                Self::Unknown(unknown) => vec![Cow::Borrowed(unknown.data.as_slice())],
+            }
         }
     }
 

--- a/src/frame/content.rs
+++ b/src/frame/content.rs
@@ -109,7 +109,7 @@ impl Content {
                 }
                 Self::Chapter(chapter) => vec![Cow::Borrowed(chapter.element_id.as_bytes())],
                 Self::MpegLocationLookupTable(_) => Vec::new(),
-                Self::Unknown(unknown) => vec![Cow::Borrowed(unknown.data.as_slice())],
+                Self::Unknown(_) => Vec::new(),
             }
         }
     }

--- a/src/frame/content.rs
+++ b/src/frame/content.rs
@@ -5,6 +5,7 @@ use crate::taglike::TagLike;
 use std::borrow::Cow;
 use std::fmt;
 use std::io;
+use crate::frame::content_cmp::ContentCmp::{Comparable, Incomparable, Same};
 
 /// The decoded contents of a [`Frame`].
 ///
@@ -56,60 +57,60 @@ pub enum Content {
 }
 
 impl Content {
-    pub(crate) fn unique(&self, deeper: bool) -> impl Eq + '_ {
+    pub(crate) fn unique(&self, deeper: bool) -> impl PartialEq + '_ {
         if deeper {
             match self {
-                Self::Text(text) => vec![Cow::Borrowed(text.as_bytes())],
-                Self::ExtendedText(extended_text) => vec![Cow::Borrowed(extended_text.description.as_bytes())],
-                Self::Link(text) => vec![Cow::Borrowed(text.as_bytes())],
-                Self::ExtendedLink(extended_link) => vec![Cow::Borrowed(extended_link.description.as_bytes())],
-                Self::Popularimeter(popularimeter) => vec![Cow::Borrowed(popularimeter.user.as_bytes())],
-                Self::Comment(comment) => vec![
+                Self::Text(text) => Comparable(vec![Cow::Borrowed(text.as_bytes())]),
+                Self::ExtendedText(extended_text) => Comparable(vec![Cow::Borrowed(extended_text.description.as_bytes())]),
+                Self::Link(text) => Comparable(vec![Cow::Borrowed(text.as_bytes())]),
+                Self::ExtendedLink(extended_link) => Comparable(vec![Cow::Borrowed(extended_link.description.as_bytes())]),
+                Self::Popularimeter(popularimeter) => Comparable(vec![Cow::Borrowed(popularimeter.user.as_bytes())]),
+                Self::Comment(comment) => Comparable(vec![
                     Cow::Borrowed(comment.lang.as_bytes()),
                     Cow::Borrowed(comment.description.as_bytes()),
-                ],
-                Self::Lyrics(lyrics) => vec![
+                ]),
+                Self::Lyrics(lyrics) => Comparable(vec![
                     Cow::Borrowed(lyrics.lang.as_bytes()),
                     Cow::Borrowed(lyrics.description.as_bytes()),
-                ],
-                Self::SynchronisedLyrics(synchronised_lyrics) => vec![
+                ]),
+                Self::SynchronisedLyrics(synchronised_lyrics) => Comparable(vec![
                     Cow::Borrowed(synchronised_lyrics.lang.as_bytes()),
                     Cow::Owned(synchronised_lyrics.content_type.to_string().as_bytes().to_owned()),
-                ],
-                Self::Picture(picture) => vec![Cow::Owned(picture.picture_type.to_string().as_bytes().to_owned())],
+                ]),
+                Self::Picture(picture) => Comparable(vec![Cow::Owned(picture.picture_type.to_string().as_bytes().to_owned())]),
                 Self::EncapsulatedObject(encapsulated_object) => {
-                    vec![Cow::Borrowed(encapsulated_object.description.as_bytes())]
+                    Comparable(vec![Cow::Borrowed(encapsulated_object.description.as_bytes())])
                 }
-                Self::Chapter(chapter) => vec![Cow::Borrowed(chapter.element_id.as_bytes())],
-                Self::MpegLocationLookupTable(_) => Vec::new(),
-                Self::Unknown(unknown) => vec![Cow::Borrowed(unknown.data.as_slice())],
+                Self::Chapter(chapter) => Comparable(vec![Cow::Borrowed(chapter.element_id.as_bytes())]),
+                Self::MpegLocationLookupTable(_) => Same,
+                Self::Unknown(_) => Incomparable,
             }
         } else {
             match self {
-                Self::Text(_) => Vec::new(),
-                Self::ExtendedText(extended_text) => vec![Cow::Borrowed(extended_text.description.as_bytes())],
-                Self::Link(_) => Vec::new(),
-                Self::ExtendedLink(extended_link) => vec![Cow::Borrowed(extended_link.description.as_bytes())],
-                Self::Popularimeter(popularimeter) => vec![Cow::Borrowed(popularimeter.user.as_bytes())],
-                Self::Comment(comment) => vec![
+                Self::Text(_) => Same,
+                Self::ExtendedText(extended_text) => Comparable(vec![Cow::Borrowed(extended_text.description.as_bytes())]),
+                Self::Link(_) => Same,
+                Self::ExtendedLink(extended_link) => Comparable(vec![Cow::Borrowed(extended_link.description.as_bytes())]),
+                Self::Popularimeter(popularimeter) => Comparable(vec![Cow::Borrowed(popularimeter.user.as_bytes())]),
+                Self::Comment(comment) => Comparable(vec![
                     Cow::Borrowed(comment.lang.as_bytes()),
                     Cow::Borrowed(comment.description.as_bytes()),
-                ],
-                Self::Lyrics(lyrics) => vec![
+                ]),
+                Self::Lyrics(lyrics) => Comparable(vec![
                     Cow::Borrowed(lyrics.lang.as_bytes()),
                     Cow::Borrowed(lyrics.description.as_bytes()),
-                ],
-                Self::SynchronisedLyrics(synchronised_lyrics) => vec![
+                ]),
+                Self::SynchronisedLyrics(synchronised_lyrics) => Comparable(vec![
                     Cow::Borrowed(synchronised_lyrics.lang.as_bytes()),
                     Cow::Owned(synchronised_lyrics.content_type.to_string().as_bytes().to_owned()),
-                ],
-                Self::Picture(picture) => vec![Cow::Owned(picture.picture_type.to_string().as_bytes().to_owned())],
+                ]),
+                Self::Picture(picture) => Comparable(vec![Cow::Owned(picture.picture_type.to_string().as_bytes().to_owned())]),
                 Self::EncapsulatedObject(encapsulated_object) => {
-                    vec![Cow::Borrowed(encapsulated_object.description.as_bytes())]
+                    Comparable(vec![Cow::Borrowed(encapsulated_object.description.as_bytes())])
                 }
-                Self::Chapter(chapter) => vec![Cow::Borrowed(chapter.element_id.as_bytes())],
-                Self::MpegLocationLookupTable(_) => Vec::new(),
-                Self::Unknown(_) => Vec::new(),
+                Self::Chapter(chapter) => Comparable(vec![Cow::Borrowed(chapter.element_id.as_bytes())]),
+                Self::MpegLocationLookupTable(_) => Same,
+                Self::Unknown(_) => Incomparable,
             }
         }
     }

--- a/src/frame/content.rs
+++ b/src/frame/content.rs
@@ -59,29 +59,29 @@ impl Content {
     pub(crate) fn unique(&self) -> impl Eq + '_ {
         match self {
             Self::Text(_) => Vec::new(),
-            Self::ExtendedText(extended_text) => vec![Cow::Borrowed(&extended_text.description)],
+            Self::ExtendedText(extended_text) => vec![Cow::Borrowed(extended_text.description.as_bytes())],
             Self::Link(_) => Vec::new(),
-            Self::ExtendedLink(extended_link) => vec![Cow::Borrowed(&extended_link.description)],
-            Self::Popularimeter(popularimeter) => vec![Cow::Borrowed(&popularimeter.user)],
+            Self::ExtendedLink(extended_link) => vec![Cow::Borrowed(extended_link.description.as_bytes())],
+            Self::Popularimeter(popularimeter) => vec![Cow::Borrowed(popularimeter.user.as_bytes())],
             Self::Comment(comment) => vec![
-                Cow::Borrowed(&comment.lang),
-                Cow::Borrowed(&comment.description),
+                Cow::Borrowed(comment.lang.as_bytes()),
+                Cow::Borrowed(comment.description.as_bytes()),
             ],
             Self::Lyrics(lyrics) => vec![
-                Cow::Borrowed(&lyrics.lang),
-                Cow::Borrowed(&lyrics.description),
+                Cow::Borrowed(lyrics.lang.as_bytes()),
+                Cow::Borrowed(lyrics.description.as_bytes()),
             ],
             Self::SynchronisedLyrics(synchronised_lyrics) => vec![
-                Cow::Borrowed(&synchronised_lyrics.lang),
-                Cow::Owned(synchronised_lyrics.content_type.to_string()),
+                Cow::Borrowed(synchronised_lyrics.lang.as_bytes()),
+                Cow::Owned(synchronised_lyrics.content_type.to_string().as_bytes().to_owned()),
             ],
-            Self::Picture(picture) => vec![Cow::Owned(picture.picture_type.to_string())],
+            Self::Picture(picture) => vec![Cow::Owned(picture.picture_type.to_string().as_bytes().to_owned())],
             Self::EncapsulatedObject(encapsulated_object) => {
-                vec![Cow::Borrowed(&encapsulated_object.description)]
+                vec![Cow::Borrowed(encapsulated_object.description.as_bytes())]
             }
-            Self::Chapter(chapter) => vec![Cow::Borrowed(&chapter.element_id)],
+            Self::Chapter(chapter) => vec![Cow::Borrowed(chapter.element_id.as_bytes())],
             Self::MpegLocationLookupTable(_) => Vec::new(),
-            Self::Unknown(_) => Vec::new(),
+            Self::Unknown(unknown) => vec![Cow::Borrowed(unknown.data.as_slice())],
         }
     }
 

--- a/src/frame/content.rs
+++ b/src/frame/content.rs
@@ -232,6 +232,15 @@ impl Content {
         }
     }
 
+    /// Returns the `Popularimeter` or None if the value is not
+    /// `Popularimeter`
+    pub fn popularimeter(&self) -> Option<&Popularimeter> {
+        match self {
+            Content::Popularimeter(popularimeter) => Some(popularimeter),
+            _ => None,
+        }
+    }
+
     /// Returns the `Unknown` or None if the value is not `Unknown`.
     #[deprecated(note = "Use to_unknown")]
     pub fn unknown(&self) -> Option<&[u8]> {

--- a/src/frame/content_cmp.rs
+++ b/src/frame/content_cmp.rs
@@ -1,0 +1,24 @@
+use std::borrow::Cow;
+
+/// used to express that some content should or should not be compared
+pub enum ContentCmp<'a> {
+    Comparable(Vec<Cow<'a, [u8]>>),
+    /// used to mark frames to be always different (for example for unknown frames)
+    Incomparable,
+    /// used to mark frames as identical regardless of their content
+    /// (for example for frames which require an unique id)
+    /// <br>(Note: both values must be <code>Same</code> or else they would not be equal)
+    Same
+}
+
+impl <'a>PartialEq for ContentCmp<'a> {
+    fn eq(&self, other: &Self) -> bool {
+        use ContentCmp::*;
+
+        match (self, other) {
+            (Comparable(c1), Comparable(c2)) => c1 == c2,
+            (Same, Same) => true,
+            _ => false
+        }
+    }
+}

--- a/src/frame/mod.rs
+++ b/src/frame/mod.rs
@@ -13,6 +13,7 @@ pub use self::timestamp::Timestamp;
 
 mod content;
 mod timestamp;
+mod content_cmp;
 
 #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
 enum ID {
@@ -42,20 +43,15 @@ impl Frame {
     pub(crate) fn compare(&self, other: &Frame) -> bool {
         if self.id == other.id {
             let content_eq = if let ID::Valid(id) = &self.id {
-                let cmp_deeper = if id == "UFID"
-                    || id == "WCOM"
-                    || id == "WOAR"
-                    || id == "RVA2"
-                    || id == "EQU2"
-                    || id == "USER"
-                    || id == "COMR"
-                    || id == "PRIV"
-                    || id == "SIGN" {
+                // some link frames are allowed to have the same id as long their content is different
+                let cmp_deeper = if id == "WCOM" || id == "WOAR" {
                     true
                 } else {
                     false
                 };
-                self.content.unique(cmp_deeper) == other.content.unique(cmp_deeper)
+                let a = self.content.unique(cmp_deeper) == other.content.unique(cmp_deeper);
+                let b = self.content.unique(cmp_deeper) == self.content.unique(cmp_deeper);
+                a
             } else {
                 self.content.unique(false) == other.content.unique(false)
             };

--- a/src/frame/mod.rs
+++ b/src/frame/mod.rs
@@ -49,9 +49,7 @@ impl Frame {
                 } else {
                     false
                 };
-                let a = self.content.unique(cmp_deeper) == other.content.unique(cmp_deeper);
-                let b = self.content.unique(cmp_deeper) == self.content.unique(cmp_deeper);
-                a
+                self.content.unique(cmp_deeper) == other.content.unique(cmp_deeper)
             } else {
                 self.content.unique(false) == other.content.unique(false)
             };

--- a/src/frame/mod.rs
+++ b/src/frame/mod.rs
@@ -42,14 +42,22 @@ impl Frame {
     pub(crate) fn compare(&self, other: &Frame) -> bool {
         if self.id == other.id {
             let content_eq = if let ID::Valid(id) = &self.id {
-                let cmp_deeper = if id == "WCOM" || id == "WOAR" {
+                let cmp_deeper = if id == "UFID"
+                    || id == "WCOM"
+                    || id == "WOAR"
+                    || id == "RVA2"
+                    || id == "EQU2"
+                    || id == "USER"
+                    || id == "COMR"
+                    || id == "PRIV"
+                    || id == "SIGN" {
                     true
                 } else {
                     false
                 };
                 self.content.unique(cmp_deeper) == other.content.unique(cmp_deeper)
             } else {
-                true
+                self.content.unique(false) == other.content.unique(false)
             };
             content_eq
                 && (self.encoding.is_none()

--- a/src/frame/mod.rs
+++ b/src/frame/mod.rs
@@ -562,4 +562,71 @@ mod tests {
             "User defined text information frame = description: value"
         );
     }
+
+    #[test]
+    fn test_frame_cmp_text() {
+        let frame_a = Frame::with_content("TIT2", Content::Text("A".to_owned()));
+        let frame_b = Frame::with_content("TIT2", Content::Text("B".to_owned()));
+
+        assert!(
+            frame_a.compare(&frame_b),
+            "frames should be counted as equal"
+        );
+    }
+
+    #[test]
+    fn test_frame_cmp_wcom() {
+        let frame_a = Frame::with_content("WCOM", Content::Link("A".to_owned()));
+        let frame_b = Frame::with_content("WCOM", Content::Link("B".to_owned()));
+
+        assert!(
+            !frame_a.compare(&frame_b),
+            "frames should not be counted as equal"
+        );
+    }
+
+    #[test]
+    fn test_frame_cmp_priv() {
+        let frame_a = Frame::with_content("PRIV", Content::Unknown(Unknown{
+            data: vec![1, 2, 3],
+            version: Version::Id3v24
+        }));
+        let frame_b = Frame::with_content("PRIV", Content::Unknown(Unknown{
+            data: vec![1, 2, 3],
+            version: Version::Id3v24
+        }));
+
+        assert!(
+            !frame_a.compare(&frame_b),
+            "frames should not be counted as equal"
+        );
+    }
+
+    #[test]
+    fn test_frame_cmp_popularimeter() {
+        let frame_a = Frame::with_content("POPM", Content::Popularimeter(Popularimeter{
+            user: "A".to_owned(),
+            rating: 1,
+            counter: 1
+        }));
+        let frame_b = Frame::with_content("POPM", Content::Popularimeter(Popularimeter{
+            user: "A".to_owned(),
+            rating: 1,
+            counter: 1
+        }));
+        let frame_c = Frame::with_content("POPM", Content::Popularimeter(Popularimeter{
+            user: "C".to_owned(),
+            rating: 1,
+            counter: 1
+        }));
+
+        assert!(
+            frame_a.compare(&frame_b),
+            "frames should be counted as equal"
+        );
+        assert!(
+            !frame_a.compare(&frame_c),
+            "frames should not be counted as equal"
+        );
+    }
 }

--- a/src/frame/mod.rs
+++ b/src/frame/mod.rs
@@ -40,11 +40,23 @@ pub struct Frame {
 impl Frame {
     /// Check if this Frame is identical to another frame
     pub(crate) fn compare(&self, other: &Frame) -> bool {
-        self.id == other.id
-            && self.content.unique() == other.content.unique()
-            && (self.encoding.is_none()
-                || other.encoding.is_none()
-                || self.encoding == other.encoding)
+        if self.id == other.id {
+            let content_eq = if let ID::Valid(id) = &self.id {
+                let cmp_deeper = if id == "WCOM" || id == "WOAR" {
+                    true
+                } else {
+                    false
+                };
+                self.content.unique(cmp_deeper) == other.content.unique(cmp_deeper)
+            } else {
+                true
+            };
+            content_eq
+                && (self.encoding.is_none()
+                || other.encoding.is_none() || self.encoding == other.encoding)
+        } else {
+            false
+        }
     }
 
     pub(crate) fn validate(&self) -> crate::Result<()> {

--- a/src/frame/mod.rs
+++ b/src/frame/mod.rs
@@ -44,14 +44,13 @@ impl Frame {
         if self.id == other.id {
             let content_eq = if let ID::Valid(id) = &self.id {
                 // some link frames are allowed to have the same id as long their content is different
-                let cmp_deeper = if id == "WCOM" || id == "WOAR" {
-                    true
+                if id == "WCOM" || id == "WOAR" {
+                    self.content.link() == other.content.link()
                 } else {
-                    false
-                };
-                self.content.unique(cmp_deeper) == other.content.unique(cmp_deeper)
+                    self.content.unique() == other.content.unique()
+                }
             } else {
-                self.content.unique(false) == other.content.unique(false)
+                self.content.unique() == other.content.unique()
             };
             content_eq
                 && (self.encoding.is_none()


### PR DESCRIPTION
Some frames which are not supported by rust-id3 are allowed to occur multiple times (for example RVA2). Until now, all except the last one are dropped.
With this PR this will not happen for frames which are allowed to occur multiple times.

Also I implemented the conversion method `popularimeter()` for Content.