### PR TITLE
Add Default to Timestamp

### DIFF
--- a/src/frame/timestamp.rs
+++ b/src/frame/timestamp.rs
@@ -13,7 +13,7 @@ use std::str::FromStr;
 /// removing as many time indicators as wanted. Hence valid timestamps
 /// are yyyy, yyyy-MM, yyyy-MM-dd, yyyy-MM-ddTHH, yyyy-MM-ddTHH:mm and
 /// yyyy-MM-ddTHH:mm:ss. All time stamps are UTC.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Hash)]
 #[allow(missing_docs)]
 pub struct Timestamp {
     pub year: i32,


### PR DESCRIPTION
This seems like a safe addition, and it would allow me to write something like this instead of enumerating the Nones: 

``` rust
tag.set_date_released(id3::Timestamp { year: 2023, ..id3::Timestamp::default() });
```

Admittedly, it would default the year to 0, not sure if this could cause practical issues somehow.