### PR TITLE
feat: add `list` example.

### DIFF
--- a/examples/list.rs
+++ b/examples/list.rs
@@ -1,0 +1,26 @@
+use id3::{Tag, TagLike};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let tag = Tag::read_from_path(
+        std::env::args_os()
+            .nth(1)
+            .ok_or("first argument is the path to read informaation from")?,
+    )?;
+
+    // Get a bunch of frames...
+    if let Some(artist) = tag.artist() {
+        println!("artist: {}", artist);
+    }
+    if let Some(title) = tag.title() {
+        println!("title: {}", title);
+    }
+    if let Some(album) = tag.album() {
+        println!("album: {}", album);
+    }
+
+    // Get frames before getting their content for more complex tags.
+    if let Some(artist) = tag.get("TPE1").and_then(|frame| frame.content().text()) {
+        println!("artist: {}", artist);
+    }
+    Ok(())
+}


### PR DESCRIPTION
It takes a single argument to a file and lists all tags it finds in it, and is taken directly from the README
with the modification of taking an argument.

I thought it would be useful to have in order to quickly see which file formats the library can read or
if it works for the files one might have at hand for integration into an audio-processing workflow.

Please feel free to close without comment if there are no examples for a reason, I just thought I'd contribute
this 'tool' as it was helpful to me :).
