### PR TITLE
feat: Added support for Table of contents frame (CTOC)

### DIFF
--- a/src/frame/mod.rs
+++ b/src/frame/mod.rs
@@ -7,7 +7,7 @@ use std::str;
 pub use self::content::{
     Chapter, Comment, Content, EncapsulatedObject, ExtendedLink, ExtendedText, Lyrics,
     MpegLocationLookupTable, MpegLocationLookupTableReference, Picture, PictureType, Popularimeter,
-    Private, SynchronisedLyrics, SynchronisedLyricsType, TimestampFormat, TableOfContents, Unknown,
+    Private, SynchronisedLyrics, SynchronisedLyricsType, TableOfContents, TimestampFormat, Unknown,
 };
 pub use self::timestamp::Timestamp;
 

--- a/src/frame/mod.rs
+++ b/src/frame/mod.rs
@@ -7,7 +7,7 @@ use std::str;
 pub use self::content::{
     Chapter, Comment, Content, EncapsulatedObject, ExtendedLink, ExtendedText, Lyrics,
     MpegLocationLookupTable, MpegLocationLookupTableReference, Picture, PictureType, Popularimeter,
-    Private, SynchronisedLyrics, SynchronisedLyricsType, TimestampFormat, Unknown,
+    Private, SynchronisedLyrics, SynchronisedLyricsType, TimestampFormat, TableOfContents, Unknown,
 };
 pub use self::timestamp::Timestamp;
 
@@ -84,6 +84,7 @@ impl Frame {
             ("CHAP", Content::Chapter(_)) => Ok(()),
             ("MLLT", Content::MpegLocationLookupTable(_)) => Ok(()),
             ("PRIV", Content::Private(_)) => Ok(()),
+            ("CTOC", Content::TableOfContents(_)) => Ok(()),
             (_, Content::Unknown(_)) => Ok(()),
             (id, content) => {
                 let content_kind = match content {
@@ -100,6 +101,7 @@ impl Frame {
                     Content::Chapter(_) => "Chapter",
                     Content::MpegLocationLookupTable(_) => "MpegLocationLookupTable",
                     Content::Private(_) => "PrivateFrame",
+                    Content::TableOfContents(_) => "TableOfContents",
                     Content::Unknown(_) => "Unknown",
                 };
                 Err(Error::new(

--- a/src/stream/frame/content.rs
+++ b/src/stream/frame/content.rs
@@ -1,7 +1,7 @@
 use crate::frame::{
     Chapter, Comment, Content, EncapsulatedObject, ExtendedLink, ExtendedText, Lyrics,
     MpegLocationLookupTable, MpegLocationLookupTableReference, Picture, PictureType, Popularimeter,
-    Private, SynchronisedLyrics, SynchronisedLyricsType, TimestampFormat, Unknown,
+    Private, SynchronisedLyrics, SynchronisedLyricsType, TimestampFormat, Unknown, TableOfContents,
 };
 use crate::stream::encoding::Encoding;
 use crate::stream::frame;
@@ -293,6 +293,10 @@ impl<W: io::Write> Encoder<W> {
         self.bytes(content.private_data.as_slice())?;
         Ok(())
     }
+
+    fn table_of_contents_content(&mut self, content: &TableOfContents) -> crate::Result<()> {
+        todo!()
+    }
 }
 
 pub fn encode(
@@ -322,6 +326,7 @@ pub fn encode(
         Content::Chapter(c) => encoder.chapter_content(c)?,
         Content::MpegLocationLookupTable(c) => encoder.mpeg_location_lookup_table_content(c)?,
         Content::Private(c) => encoder.private_content(c)?,
+        Content::TableOfContents(c) => encoder.table_of_contents_content(c)?,
         Content::Unknown(c) => encoder.bytes(&c.data)?,
     };
 
@@ -378,6 +383,7 @@ pub fn decode(
         "CHAP" => decoder.chapter_content(),
         "MLLT" => decoder.mpeg_location_lookup_table_content(),
         "PRIV" => decoder.private_content(),
+        "CTOC" => decoder.table_of_contents_content(),
         _ => Ok(Content::Unknown(Unknown { data, version })),
     }?;
     Ok((content, encoding))
@@ -776,6 +782,9 @@ impl<'a> Decoder<'a> {
             owner_identifier,
             private_data,
         }))
+    }
+    fn table_of_contents_content(mut self) -> crate::Result<Content> {
+        todo!()
     }
 }
 

--- a/src/stream/frame/content.rs
+++ b/src/stream/frame/content.rs
@@ -1,7 +1,7 @@
 use crate::frame::{
     Chapter, Comment, Content, EncapsulatedObject, ExtendedLink, ExtendedText, Lyrics,
     MpegLocationLookupTable, MpegLocationLookupTableReference, Picture, PictureType, Popularimeter,
-    Private, SynchronisedLyrics, SynchronisedLyricsType, TimestampFormat, Unknown, TableOfContents,
+    Private, SynchronisedLyrics, SynchronisedLyricsType, TableOfContents, TimestampFormat, Unknown,
 };
 use crate::stream::encoding::Encoding;
 use crate::stream::frame;
@@ -811,21 +811,20 @@ impl<'a> Decoder<'a> {
         let ordered = matches!(!!(flags & 1), 1);
         let element_count = self.byte()?;
         let mut elements = Vec::new();
-        for _ in 0 ..element_count {
+        for _ in 0..element_count {
             elements.push(self.string_delimited(Encoding::Latin1)?);
         }
         let mut frames = Vec::new();
         while let Some((_advance, frame)) = frame::decode(&mut self.r, self.version)? {
             frames.push(frame);
         }
-        Ok(Content::TableOfContents(TableOfContents{
+        Ok(Content::TableOfContents(TableOfContents {
             element_id,
             top_level,
             ordered,
             elements,
             frames,
         }))
-
     }
 }
 

--- a/src/stream/tag.rs
+++ b/src/stream/tag.rs
@@ -470,7 +470,7 @@ mod tests {
     use crate::frame::{
         Chapter, Content, EncapsulatedObject, Frame, MpegLocationLookupTable,
         MpegLocationLookupTableReference, Picture, PictureType, Popularimeter, SynchronisedLyrics,
-        SynchronisedLyricsType, TimestampFormat, Unknown,
+        SynchronisedLyricsType, TimestampFormat, Unknown, TableOfContents,
     };
     use std::fs;
     use std::io::{self, Read};
@@ -530,6 +530,13 @@ mod tests {
                     Frame::with_content("TALB", Content::Text("Bar".to_string())),
                     Frame::with_content("TCON", Content::Text("Baz".to_string())),
                 ],
+            });
+            tag.add_frame(TableOfContents {
+                element_id: "table01".to_string(),
+                top_level: true,
+                ordered: true,
+                elements: vec!["01".to_string()],
+                frames: Vec::new(),
             });
             tag.add_frame(MpegLocationLookupTable {
                 frames_between_reference: 1,

--- a/src/stream/tag.rs
+++ b/src/stream/tag.rs
@@ -470,7 +470,7 @@ mod tests {
     use crate::frame::{
         Chapter, Content, EncapsulatedObject, Frame, MpegLocationLookupTable,
         MpegLocationLookupTableReference, Picture, PictureType, Popularimeter, SynchronisedLyrics,
-        SynchronisedLyricsType, TimestampFormat, Unknown, TableOfContents,
+        SynchronisedLyricsType, TableOfContents, TimestampFormat, Unknown,
     };
     use std::fs;
     use std::io::{self, Read};
@@ -683,7 +683,7 @@ mod tests {
         let mut file = fs::File::open("testdata/id3v23_chap.id3").unwrap();
         let tag = decode(&mut file).unwrap();
         assert_eq!(tag.chapters().count(), 7);
-        
+
         let chapter_titles = tag
             .chapters()
             .map(|chap| chap.frames.first().unwrap().content().text().unwrap())
@@ -707,30 +707,19 @@ mod tests {
         let mut file = fs::File::open("testdata/id3v23_chap.id3").unwrap();
         let tag = decode(&mut file).unwrap();
         assert_eq!(tag.tables_of_contents().count(), 1);
-        
-        for x in tag.tables_of_contents(){
-            println!("{:?}",x);
+
+        for x in tag.tables_of_contents() {
+            println!("{:?}", x);
         }
 
-        let ctoc = tag
-            .tables_of_contents()
-            .last()
-            .unwrap();
+        let ctoc = tag.tables_of_contents().last().unwrap();
 
         assert_eq!(ctoc.element_id, "toc");
         assert!(ctoc.top_level);
         assert!(ctoc.ordered);
         assert_eq!(
             ctoc.elements,
-            &[
-                "chp0",
-                "chp1",
-                "chp2",
-                "chp3",
-                "chp4",
-                "chp5",
-                "chp6"
-            ]
+            &["chp0", "chp1", "chp2", "chp3", "chp4", "chp5", "chp6"]
         );
         assert!(ctoc.frames.is_empty());
     }

--- a/src/stream/tag.rs
+++ b/src/stream/tag.rs
@@ -683,7 +683,7 @@ mod tests {
         let mut file = fs::File::open("testdata/id3v23_chap.id3").unwrap();
         let tag = decode(&mut file).unwrap();
         assert_eq!(tag.chapters().count(), 7);
-
+        
         let chapter_titles = tag
             .chapters()
             .map(|chap| chap.frames.first().unwrap().content().text().unwrap())
@@ -700,6 +700,39 @@ mod tests {
                 "Apple’s September"
             ]
         );
+    }
+
+    #[test]
+    fn read_id3v23_ctoc() {
+        let mut file = fs::File::open("testdata/id3v23_chap.id3").unwrap();
+        let tag = decode(&mut file).unwrap();
+        assert_eq!(tag.tables_of_contents().count(), 1);
+        
+        for x in tag.tables_of_contents(){
+            println!("{:?}",x);
+        }
+
+        let ctoc = tag
+            .tables_of_contents()
+            .last()
+            .unwrap();
+
+        assert_eq!(ctoc.element_id, "toc");
+        assert!(ctoc.top_level);
+        assert!(ctoc.ordered);
+        assert_eq!(
+            ctoc.elements,
+            &[
+                "chp0",
+                "chp1",
+                "chp2",
+                "chp3",
+                "chp4",
+                "chp5",
+                "chp6"
+            ]
+        );
+        assert!(ctoc.frames.is_empty());
     }
 
     #[test]

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -1,7 +1,7 @@
 use crate::chunk;
 use crate::frame::{
     Chapter, Comment, EncapsulatedObject, ExtendedLink, ExtendedText, Frame, Lyrics, Picture,
-    SynchronisedLyrics,
+    SynchronisedLyrics, TableOfContents,
 };
 use crate::storage::{PlainStorage, Storage};
 use crate::stream;
@@ -385,6 +385,42 @@ impl<'a> Tag {
     pub fn chapters(&self) -> impl Iterator<Item = &Chapter> {
         self.frames().filter_map(|frame| frame.content().chapter())
     }
+
+    /// Returns an iterator over all tables of contents (CTOC) in the tag.
+    ///
+    /// # Example
+    /// ```
+    /// use id3::{Tag, TagLike};
+    /// use id3::frame::{Chapter, TableOfContents, Content, Frame};
+    ///
+    /// let mut tag = Tag::new();
+    /// tag.add_frame(Chapter{
+    ///     element_id: "chap01".to_string(),
+    ///     start_time: 1000,
+    ///     end_time: 2000,
+    ///     start_offset: 0xff,
+    ///     end_offset: 0xff,
+    ///     frames: Vec::new(),
+    /// });
+    /// tag.add_frame(TableOfContents{
+    ///     element_id: "internalTable01".to_string(),
+    ///     top_level: false,
+    ///     ordered: false,
+    ///     elements: Vec::new(),
+    ///     frames: Vec::new(),
+    /// });
+    /// tag.add_frame(TableOfContents{
+    ///     element_id: "01".to_string(),
+    ///     top_level: true,
+    ///     ordered: true,
+    ///     elements: ["internalTable01".to_string(),"chap01".to_string()],
+    ///     frames: Vec::new(),
+    /// });
+    /// assert_eq!(2, tag.tables_of_contents().count());
+    /// ```
+    pub fn tables_of_contents(&self) -> impl Iterator<Item = &TableOfContents> {
+    self.frames().filter_map(|frame| frame.content().table_of_contents())
+}
 }
 
 impl PartialEq for Tag {

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -419,8 +419,9 @@ impl<'a> Tag {
     /// assert_eq!(2, tag.tables_of_contents().count());
     /// ```
     pub fn tables_of_contents(&self) -> impl Iterator<Item = &TableOfContents> {
-    self.frames().filter_map(|frame| frame.content().table_of_contents())
-}
+        self.frames()
+            .filter_map(|frame| frame.content().table_of_contents())
+    }
 }
 
 impl PartialEq for Tag {

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -413,7 +413,7 @@ impl<'a> Tag {
     ///     element_id: "01".to_string(),
     ///     top_level: true,
     ///     ordered: true,
-    ///     elements: ["internalTable01".to_string(),"chap01".to_string()],
+    ///     elements: vec!["internalTable01".to_string(),"chap01".to_string()],
     ///     frames: Vec::new(),
     /// });
     /// assert_eq!(2, tag.tables_of_contents().count());

--- a/src/taglike.rs
+++ b/src/taglike.rs
@@ -1435,7 +1435,7 @@ pub trait TagLike: private::Sealed {
     ///     element_id: "01".to_string(),
     ///     top_level: true,
     ///     ordered: true,
-    ///     elements: ["chap01".to_string()],
+    ///     elements: vec!["chap01".to_string()],
     ///     frames: Vec::new(),
     /// });
     /// assert_eq!(1, tag.tables_of_contents().count());

--- a/src/taglike.rs
+++ b/src/taglike.rs
@@ -1391,7 +1391,7 @@ pub trait TagLike: private::Sealed {
         self.remove("SYLT");
     }
 
-    /// Adds a single chapter (CHAP) to the farme.
+    /// /// Removes all chapters (CHAP) frames from the tag.
     ///
     /// # Example
     /// ```
@@ -1414,15 +1414,48 @@ pub trait TagLike: private::Sealed {
     fn remove_all_chapters(&mut self) {
         self.remove("CHAP");
     }
+
+    /// /// Removes all tables of contents (CTOC) frames from the tag.
+    ///
+    /// # Example
+    /// ```
+    /// use id3::{Tag, TagLike};
+    /// use id3::frame::{Chapter, TableOfContents, Content, Frame};
+    ///
+    /// let mut tag = Tag::new();
+    /// tag.add_frame(Chapter{
+    ///     element_id: "chap01".to_string(),
+    ///     start_time: 1000,
+    ///     end_time: 2000,
+    ///     start_offset: 0xff,
+    ///     end_offset: 0xff,
+    ///     frames: Vec::new(),
+    /// });
+    /// tag.add_frame(TableOfContents{
+    ///     element_id: "01".to_string(),
+    ///     top_level: true,
+    ///     ordered: true,
+    ///     elements: ["chap01".to_string()],
+    ///     frames: Vec::new(),
+    /// });
+    /// assert_eq!(1, tag.tables_of_contents().count());
+    /// tag.remove_all_tables_of_contents();
+    /// assert_eq!(0, tag.tables_of_contents().count());
+    /// ```
+    fn remove_all_tables_of_contents(&mut self) {
+        self.remove("CTOC");
+    }
 }
 
 // https://rust-lang.github.io/api-guidelines/future-proofing.html#c-sealed
 mod private {
     use crate::frame::Chapter;
+    use crate::frame::TableOfContents;
     use crate::tag::Tag;
 
     pub trait Sealed {}
 
     impl Sealed for Tag {}
     impl Sealed for Chapter {}
+    impl Sealed for TableOfContents {}
 }


### PR DESCRIPTION
Closes #99 
CTOC and CHAP frames are closely related and widely used in the world of podcasting.

Useful link:
[Reference doc](https://mutagen-specs.readthedocs.io/en/latest/id3/id3v2-chapters-1.0.html) 
[NodeJS implementation](https://github.com/Zazama/node-id3/blob/master/src/frames/frame-ctoc.ts) 