### PR TITLE
chore: bump byteorder to 1.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ include = ["src/*", "Cargo.toml", "LICENSE", "README.md"]
 
 [dependencies]
 bitflags = "2.0"
-byteorder = "1.4"
+byteorder = "1.5"
 flate2 = "1"
 tokio = { version = "1.21", default-features = false, features = ["rt", "macros", "io-util", "fs"], optional = true}
 


### PR DESCRIPTION
This version contains some safety and perf improvements.