### PR TITLE
feat: make file-related APIs compatible with io::Cursor

### DIFF
--- a/src/chunk.rs
+++ b/src/chunk.rs
@@ -1,9 +1,8 @@
 use crate::storage::{PlainStorage, Storage};
-use crate::{Error, ErrorKind, Tag, Version};
+use crate::{Error, ErrorKind, StorageFile, Tag, Version};
 use byteorder::{BigEndian, ByteOrder, LittleEndian};
 use std::convert::TryFrom;
 use std::fmt;
-use std::fs;
 use std::io::prelude::*;
 use std::io::{BufReader, Seek, SeekFrom};
 use std::{convert::TryInto, io};
@@ -36,7 +35,7 @@ where
 /// Writes a tag to the given file. If the file contains no previous tag data, a new ID3
 /// chunk is created. Otherwise, the tag is overwritten in place.
 pub fn write_id3_chunk_file<F: ChunkFormat>(
-    mut file: &mut fs::File,
+    mut file: impl StorageFile,
     tag: &Tag,
     version: Version,
 ) -> crate::Result<()> {

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -117,7 +117,7 @@ impl<'a> Tag {
     /// Removes an ID3v2 tag from the specified file.
     ///
     /// Returns true if the file initially contained a tag.
-    pub fn remove_from_file(mut file: &mut fs::File) -> crate::Result<bool> {
+    pub fn remove_from_file(mut file: impl StorageFile) -> crate::Result<bool> {
         let location = match stream::tag::locate_id3v2(&mut file)? {
             Some(l) => l,
             None => return Ok(false),
@@ -167,7 +167,7 @@ impl<'a> Tag {
     }
 
     /// Reads an AIFF file and returns any present ID3 tag.
-    pub fn read_from_aiff_file(file: &mut fs::File) -> crate::Result<Tag> {
+    pub fn read_from_aiff_file(file: impl StorageFile) -> crate::Result<Tag> {
         chunk::load_id3_chunk::<chunk::AiffFormat, _>(file)
     }
 
@@ -183,7 +183,7 @@ impl<'a> Tag {
     }
 
     /// Reads an WAV file and returns any present ID3 tag.
-    pub fn read_from_wav_file(file: &mut fs::File) -> crate::Result<Tag> {
+    pub fn read_from_wav_file(file: impl StorageFile) -> crate::Result<Tag> {
         chunk::load_id3_chunk::<chunk::WavFormat, _>(file)
     }
 
@@ -237,7 +237,11 @@ impl<'a> Tag {
     }
 
     /// Overwrite AIFF file ID3 chunk in a file. The file must be opened read/write.
-    pub fn write_to_aiff_file(&self, file: &mut fs::File, version: Version) -> crate::Result<()> {
+    pub fn write_to_aiff_file(
+        &self,
+        file: impl StorageFile,
+        version: Version,
+    ) -> crate::Result<()> {
         chunk::write_id3_chunk_file::<chunk::AiffFormat>(file, self, version)
     }
 
@@ -255,7 +259,7 @@ impl<'a> Tag {
     }
 
     /// Overwrite AIFF file ID3 chunk in a file. The file must be opened read/write.
-    pub fn write_to_wav_file(&self, file: &mut fs::File, version: Version) -> crate::Result<()> {
+    pub fn write_to_wav_file(&self, file: impl StorageFile, version: Version) -> crate::Result<()> {
         chunk::write_id3_chunk_file::<chunk::WavFormat>(file, self, version)
     }
 


### PR DESCRIPTION
The codebase defines a StorageFile trait to model anything similar to a file. By using `impl StorageFile` instead of `fs::File` in the API signatures, users are able to provide either a file or something similar (for example, `io::Cursor` to manipulate a block of data in memory).

This commit updates the APIs still using `fs::File` to `impl StorageFile`.