### PR TITLE
ci: Add MSRV test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,9 +47,7 @@ jobs:
         shell: powershell
 
       - name: Set up Rust toolchain
-        uses: dtolnay/rust-toolchain@v1
-        with:
-          toolchain: stable
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Cache dependencies
         uses: actions/cache@v4
@@ -70,6 +68,16 @@ jobs:
       - name: Run tests
         run: cargo test --all-features --no-fail-fast
 
+  msrv:
+    name: Current MSRV is 1.65.0
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    # Now check that `cargo build` works with respect to the oldest possible
+    # deps and the stated MSRV
+    - uses: dtolnay/rust-toolchain@1.65.0
+    - run: cargo build --all-features
+
   style:
     runs-on: ubuntu-latest
     steps:
@@ -77,9 +85,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Rust toolchain
-        uses: dtolnay/rust-toolchain@v1
-        with:
-          toolchain: stable
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Cache dependencies
         uses: actions/cache@v4


### PR DESCRIPTION
Assuming MSRV 1.65

Fixes #127 

Depends on fix for #126 re-based in

Failure as expected with 1.65: https://github.com/pinkforest/rust-id3/actions/runs/8002170702/job/21854841329
Where as current stable works ok.
