### PR TITLE
fix: Allow MSRV 1.63 with range match usize behavioral change

### DIFF
--- a/src/stream/frame/content.rs
+++ b/src/stream/frame/content.rs
@@ -586,6 +586,9 @@ impl<'a> Decoder<'a> {
             let r = match self.r.len() {
                 0..=8 => self.r,
                 9.. => &self.r[..8],
+                // issue #126
+                #[allow(unreachable_patterns)]
+                _ => unimplemented!(),
             };
             let mut bin = [0; 8];
             bin[8 - r.len()..].copy_from_slice(r);


### PR DESCRIPTION
Fixes #126 

This allows the library work rustc >= 1.63