### PR TITLE
feat: Add support for UFID frames (#136)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ A library for reading and writing ID3 metadata.
 * Unsynchronisation
 * Compression
 * MPEG Location Lookup Table frames
+* Unique File Identifier frames
 * Tag and File Alter Preservation bits
 
 ## Examples

--- a/src/stream/tag.rs
+++ b/src/stream/tag.rs
@@ -497,9 +497,9 @@ mod tests {
     use crate::frame::{
         Chapter, Content, EncapsulatedObject, Frame, MpegLocationLookupTable,
         MpegLocationLookupTableReference, Picture, PictureType, Popularimeter, SynchronisedLyrics,
-        SynchronisedLyricsType, TableOfContents, TimestampFormat, Unknown,
+        SynchronisedLyricsType, TableOfContents, TimestampFormat, UniqueFileIdentifier, Unknown,
     };
-    use std::fs;
+    use std::fs::{self};
     use std::io::{self, Read};
 
     fn make_tag(version: Version) -> Tag {
@@ -581,6 +581,14 @@ mod tests {
                         deviate_millis: 0x0,
                     },
                 ],
+            });
+            tag.add_frame(UniqueFileIdentifier {
+                owner_identifier: String::from("http://www.id3.org/dummy/ufid.html"),
+                identifier: "7FZo5fMqyG5Ys1dm8F1FHa".into(),
+            });
+            tag.add_frame(UniqueFileIdentifier {
+                owner_identifier: String::from("example.com"),
+                identifier: "3107f6e3-99c0-44c1-9785-655fc9c32d8b".into(),
             });
         }
         tag
@@ -1036,5 +1044,38 @@ mod tests {
         tag.set_total_tracks(16);
         assert_eq!(tag.track(), Some(9));
         assert_eq!(tag.total_tracks(), Some(16));
+    }
+
+    #[test]
+    fn write_id3v24_ufids() {
+        let mut tag = make_tag(Version::Id3v24);
+        tag.add_frame(UniqueFileIdentifier {
+            owner_identifier: String::from("http://www.id3.org/dummy/ufid.html"),
+            identifier: "7FZo5fMqyG5Ys1dm8F1FHa".into(),
+        });
+        assert_eq!(tag.unique_file_identifiers().count(), 2);
+
+        tag.add_frame(UniqueFileIdentifier {
+            owner_identifier: String::from("http://www.id3.org/dummy/ufid.html"),
+            identifier: "09FxXfNTQsCgzkPmCeFwlr".into(),
+        });
+        assert_eq!(tag.unique_file_identifiers().count(), 2);
+
+        tag.add_frame(UniqueFileIdentifier {
+            owner_identifier: String::from("open.blotchify.com"),
+            identifier: "09FxXfNTQsCgzkPmCeFwlr".into(),
+        });
+
+        assert_eq!(tag.unique_file_identifiers().count(), 3);
+
+        let mut buffer = Vec::new();
+        Encoder::new()
+            .compression(true)
+            .version(Version::Id3v24)
+            .encode(&tag, &mut buffer)
+            .unwrap();
+        let tag_read = decode(&mut io::Cursor::new(buffer)).unwrap();
+
+        assert_eq!(tag, tag_read);
     }
 }

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -1,7 +1,7 @@
 use crate::chunk;
 use crate::frame::{
     Chapter, Comment, EncapsulatedObject, ExtendedLink, ExtendedText, Frame, Lyrics, Picture,
-    SynchronisedLyrics, TableOfContents,
+    SynchronisedLyrics, TableOfContents, UniqueFileIdentifier,
 };
 use crate::storage::{plain::PlainStorage, Format, Storage};
 use crate::stream;
@@ -403,6 +403,31 @@ impl<'a> Tag {
     /// ```
     pub fn pictures(&'a self) -> impl Iterator<Item = &'a Picture> + 'a {
         self.frames().filter_map(|frame| frame.content().picture())
+    }
+
+    /// Returns an iterator over the Unique File Identifiers (ufid) in the tag.
+    ///
+    /// # Example
+    /// ```
+    /// use id3::{Frame, Tag, TagLike};
+    /// use id3::frame::{Content, UniqueFileIdentifier};
+    ///
+    /// let mut tag = Tag::new();
+    ///
+    /// let unique_file_identifier = UniqueFileIdentifier {
+    ///     owner_identifier: String::from("http://www.id3.org/dummy/ufid.html"),
+    ///     identifier: "7FZo5fMqyG5Ys1dm8F1FHa".into(),
+    /// };
+    /// tag.add_frame(Frame::with_content("UFID", Content::UniqueFileIdentifier(unique_file_identifier.clone())));
+    /// tag.add_frame(Frame::with_content("UFID", Content::UniqueFileIdentifier(unique_file_identifier.clone())));
+    ///
+    /// assert_eq!(tag.unique_file_identifiers().count(), 1);
+    /// ```
+    pub fn unique_file_identifiers(
+        &'a self,
+    ) -> impl Iterator<Item = &'a UniqueFileIdentifier> + 'a {
+        self.frames()
+            .filter_map(|frame| frame.content().unique_file_identifier())
     }
 
     /// Returns an iterator over all chapters (CHAP) in the tag.


### PR DESCRIPTION
This PR implements UFID frames.

This pull includes: 
* Content::Ufid()
* Ufid struct with owner_identifier and identifier fields
* remove_all_ufids()
* remove_ufid_by_owner_identifier()
* tests for the above items


The spec indicates that `owner_identifier` cannot be the empty string, and that `identifier` is up to a max of 64 bytes long, but I didn't know where to implement these limitations. Let me know if you have suggestions.

For better display purposes, I also made the impl display for the Ufid struct a little different from the others, where it will first try to decode the `identifier` bytes into a utf-8 string, and then print the `{:x?}` format if it fails to decode.

Closes #136 