### PR TITLE
Fix: missing null byte delimeter in PrivateFrame

### DIFF
--- a/src/stream/frame/content.rs
+++ b/src/stream/frame/content.rs
@@ -290,6 +290,7 @@ impl<W: io::Write> Encoder<W> {
 
     fn private_content(&mut self, content: &Private) -> crate::Result<()> {
         self.bytes(content.owner_identifier.as_bytes())?;
+        self.byte(0)?;
         self.bytes(content.private_data.as_slice())?;
         Ok(())
     }

--- a/src/stream/tag.rs
+++ b/src/stream/tag.rs
@@ -496,8 +496,8 @@ mod tests {
     use super::*;
     use crate::frame::{
         Chapter, Content, EncapsulatedObject, Frame, MpegLocationLookupTable,
-        MpegLocationLookupTableReference, Picture, PictureType, Popularimeter, SynchronisedLyrics,
-        SynchronisedLyricsType, TableOfContents, TimestampFormat, Unknown,
+        MpegLocationLookupTableReference, Picture, PictureType, Popularimeter, Private,
+        SynchronisedLyrics, SynchronisedLyricsType, TableOfContents, TimestampFormat, Unknown,
     };
     use std::fs;
     use std::io::{self, Read};
@@ -581,6 +581,10 @@ mod tests {
                         deviate_millis: 0x0,
                     },
                 ],
+            });
+            tag.add_frame(Private {
+                owner_identifier: "PrivateFrameIdentifier1".to_string(),
+                private_data: "SomePrivateBytes".into(),
             });
         }
         tag


### PR DESCRIPTION
The spec for PrivateFrames says that a null byte should be inserted after the `owner_identifier` field.

Currently, if one adds a private frame, they will encounter read failures when decoding tags.

This PR adds the null byte to the encoder which lets tags with PrivateFrames be decoded properly.