### PR TITLE
Only replace `/` in the ID3v2.2/2.3 frames mentioned in the spec

### DIFF
--- a/src/stream/tag.rs
+++ b/src/stream/tag.rs
@@ -509,7 +509,7 @@ mod tests {
         tag.set_artist("Artist");
         tag.set_genre("Genre");
         tag.add_frame(Frame::with_content(
-            "TPE4",
+            "TPE1",
             Content::new_text_values(["artist 1", "artist 2", "artist 3"]),
         ));
         tag.set_duration(1337);

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -1020,7 +1020,7 @@ mod tests {
         let genres = tag.genres();
         let artists = tag.artists();
 
-        assert_eq!(genres, Some(vec!["Pop", "Trip-Hop"]));
+        assert_eq!(genres, Some(vec!["Pop/Trip-Hop"]));
         assert_eq!(artists, Some(vec!["First", "Secondary"]));
     }
 


### PR DESCRIPTION
Fixes #103 (at least partially - there is still no proper fix for the "AC/DC problem").

See https://github.com/polyfloyd/rust-id3/issues/103#issuecomment-2495061517 for details.